### PR TITLE
Fix daily report workflow dependency install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,3 @@ mcp-python>=0.1.0
 anthropic
 elevenlabs
 pydub
-audioop-lts; python_version >= "3.13"


### PR DESCRIPTION
## Summary

- remove the non-installable `audioop-lts` requirement that blocks scheduled report runs before generation starts
- restore the GitHub Actions path that regenerates `index.md` and `executive_summary.mp3`
- validate the fix with a real `workflow_dispatch` run on the branch

## Validation

- `python3 -m pip install --dry-run -r requirements.txt`
- isolated `pip==26.0.1` dry-run install against `requirements.txt`
- GitHub Actions run `23328877778` on `ric-226-fix-podcast-refresh` (success)

Refs RIC-226
