### PR TITLE
RIC-224: Update GitHub Actions for Node 24 runtime

### DIFF
--- a/.github/workflows/generate-report.yml
+++ b/.github/workflows/generate-report.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.PAT_GITHUB }}
       
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       


### PR DESCRIPTION
## Summary
- upgrade checkout to the first Node 24-compatible major
- upgrade setup-python to the Node 24-compatible major
- keep the report workflow behavior unchanged aside from the action runtime bump

## Validation
- git diff --check
- gh run view 23438074582 -R ricomanifesto/SentryInsight --log | rg -n "Node\.js 20|checkout@v3|setup-python@v4"