### PR TITLE
Fix stale podcast artifacts when ElevenLabs quota exhausted (RIC-228)

### DIFF
--- a/.github/workflows/generate-report.yml
+++ b/.github/workflows/generate-report.yml
@@ -45,6 +45,15 @@ jobs:
           VT_INTELLIGENCE_API_KEY: ${{ secrets.VT_INTELLIGENCE_API_KEY }}
           GOOGLE_TI_API_KEY: ${{ secrets.GOOGLE_TI_API_KEY }}
       
+      - name: Check for podcast quota skip
+        run: |
+          if [ -f podcast/PODCAST_SKIPPED ]; then
+            echo "::warning::Podcast generation was skipped this run — ElevenLabs quota exhausted. podcast/latest.mp3 and podcast.xml were NOT updated."
+            echo "--- Skip marker contents ---"
+            cat podcast/PODCAST_SKIPPED
+            echo "----------------------------"
+          fi
+
       - name: Validate report content before publishing
         run: |
           if grep -qE "Error code: 400|credit balance is too low|Error Generating Exploitation Report" index.md 2>/dev/null; then

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ Thumbs.db
 
 # Private notes (do not commit)
 docs/notes/
+
+# Runtime CI markers (transient, not part of published content)
+podcast/PODCAST_SKIPPED

--- a/src/core/workflow.py
+++ b/src/core/workflow.py
@@ -11,6 +11,7 @@ from ..services.rss_mcp import fetch_rss_feed, enrich_rss_articles  # Import the
 from .analyze import filter_exploitation_articles, analyze_exploitation
 from ..services.publish import publish_to_github_pages
 from ..services.audio import (
+    ElevenLabsQuotaExhaustedError,
     generate_executive_summary_audio,
     extract_threat_actor_section,
     generate_podcast_script,
@@ -184,6 +185,14 @@ async def generate_audio(state: ExploitationAnalysisState) -> ExploitationAnalys
 
     return state
 
+def _write_podcast_skip_marker(date: str, reason: str) -> None:
+    """Write a marker file so the CI step can emit a visible annotation."""
+    marker_path = Path("podcast/PODCAST_SKIPPED")
+    marker_path.parent.mkdir(parents=True, exist_ok=True)
+    marker_path.write_text(f"date={date}\nreason=quota_exhausted\ndetail={reason}\n")
+    logger.warning(f"Wrote podcast skip marker to {marker_path}")
+
+
 async def generate_podcast(state: ExploitationAnalysisState) -> ExploitationAnalysisState:
     """Generate a podcast episode from the Threat Actor Activities section."""
     logger.info("Generating threat actor podcast")
@@ -213,8 +222,19 @@ async def generate_podcast(state: ExploitationAnalysisState) -> ExploitationAnal
     episode_path = f"podcast/{episode_filename}"
     raw_narration_path = f"podcast/raw_narration_{today}.mp3"
 
-    success = generate_podcast_audio(script, raw_narration_path)
+    try:
+        success = generate_podcast_audio(script, raw_narration_path)
+    except ElevenLabsQuotaExhaustedError as e:
+        logger.error(
+            "::error::Podcast generation skipped — ElevenLabs quota exhausted. "
+            "podcast/latest.mp3 and podcast.xml were NOT updated this run. "
+            f"Detail: {e}"
+        )
+        _write_podcast_skip_marker(today, str(e))
+        return state
+
     if not success:
+        logger.warning("Podcast audio generation failed — skipping podcast")
         return state
 
     # Produce the final episode with intro, background music, transitions, and outro

--- a/src/services/audio.py
+++ b/src/services/audio.py
@@ -9,6 +9,25 @@ from time import mktime
 
 logger = logging.getLogger(__name__)
 
+
+class ElevenLabsQuotaExhaustedError(Exception):
+    """Raised when ElevenLabs TTS fails due to insufficient credit balance."""
+    pass
+
+
+def _is_quota_exhausted(exc: Exception) -> bool:
+    """Return True if the exception indicates an ElevenLabs quota/credit error."""
+    err_str = str(exc).lower()
+    quota_indicators = [
+        "quota_exceeded",
+        "credit balance is too low",
+        "insufficient credits",
+        "exceeded your quota",
+        "out of credits",
+    ]
+    return any(indicator in err_str for indicator in quota_indicators)
+
+
 # Rachel - calm, professional female voice
 VOICE_ID = "21m00Tcm4TlvDq8ikWAM"
 MODEL_ID = "eleven_multilingual_v2"
@@ -143,6 +162,12 @@ def generate_podcast_audio(script: str, output_path: str) -> bool:
         logger.info(f"Podcast audio saved to {output_path}")
         return True
     except Exception as e:
+        if _is_quota_exhausted(e):
+            logger.error(
+                f"ElevenLabs quota exhausted — cannot generate podcast audio. "
+                f"podcast/latest.mp3 and podcast.xml will NOT be updated this run. Detail: {e}"
+            )
+            raise ElevenLabsQuotaExhaustedError(str(e)) from e
         logger.error(f"Error generating podcast audio: {e}")
         return False
 
@@ -379,5 +404,10 @@ async def generate_executive_summary_audio(report_markdown: str, output_path: st
         logger.info(f"Audio saved to {output_path}")
         return True
     except Exception as e:
-        logger.error(f"Error generating audio: {e}")
+        if _is_quota_exhausted(e):
+            logger.error(
+                f"ElevenLabs quota exhausted — executive_summary.mp3 will NOT be updated this run. Detail: {e}"
+            )
+        else:
+            logger.error(f"Error generating audio: {e}")
         return False


### PR DESCRIPTION
## Summary

- **Root cause**: `generate_podcast_audio()` caught all ElevenLabs exceptions generically, returning `False` with a log line. The quota_exceeded error was indistinguishable from any other failure, and the workflow silently skipped updating `podcast/latest.mp3` and `podcast.xml`, leaving stale artifacts from the prior run.
- **Fix**: Add `ElevenLabsQuotaExhaustedError` so the quota case is typed and unambiguous, propagate it up to the workflow node, write a `podcast/PODCAST_SKIPPED` marker file, and add a CI step that emits a `::warning::` annotation visible in the Actions summary.

## Changes

| File | What changed |
|---|---|
| `src/services/audio.py` | `ElevenLabsQuotaExhaustedError` exception class + `_is_quota_exhausted()` helper; `generate_podcast_audio()` raises typed exception on quota errors; `generate_executive_summary_audio()` logs quota errors distinctly |
| `src/core/workflow.py` | `generate_podcast()` catches `ElevenLabsQuotaExhaustedError` explicitly, logs `::error::` with clear message, writes `podcast/PODCAST_SKIPPED` marker |
| `.github/workflows/generate-report.yml` | New "Check for podcast quota skip" step reads marker file and emits `::warning::` annotation — run does not fail (report refresh still published) |
| `.gitignore` | Exclude `podcast/PODCAST_SKIPPED` as a transient CI artifact |

## Test plan

- [ ] Simulate quota exhaustion by temporarily setting an invalid/empty `ELEVENLABS_API_KEY` and verifying the new `::warning::` annotation appears in the Actions run summary
- [ ] Verify `podcast/latest.mp3` and `podcast.xml` remain unchanged (stale, but deterministically so) when the marker is written
- [ ] Verify a normal run with credits available still produces a fresh episode and no marker file is written
- [ ] Confirm `podcast/PODCAST_SKIPPED` is not committed to git on a successful skip run

🤖 Generated with [Claude Code](https://claude.com/claude-code)