### PR TITLE
Add report validation and model safeguards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 # Copy this file to .env and fill in your API keys
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
+SENTRYINSIGHT_ANTHROPIC_MODEL=claude-sonnet-4-6

--- a/.github/workflows/generate-report.yml
+++ b/.github/workflows/generate-report.yml
@@ -30,11 +30,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+
+      - name: Run local validation
+        run: bash scripts/local_validation.sh
       
       - name: Generate exploitation report
         run: python main.py
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          SENTRYINSIGHT_ANTHROPIC_MODEL: ${{ vars.SENTRYINSIGHT_ANTHROPIC_MODEL || 'claude-sonnet-4-6' }}
           ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
           # Pass VT Intelligence API key under multiple common env names
           VT_API_KEY: ${{ secrets.VT_API_KEY }}
@@ -43,12 +47,7 @@ jobs:
           GOOGLE_TI_API_KEY: ${{ secrets.GOOGLE_TI_API_KEY }}
       
       - name: Validate report content before publishing
-        run: |
-          if grep -qE "Error code: 400|credit balance is too low|Error Generating Exploitation Report" index.md 2>/dev/null; then
-            echo "::error::Report contains API error — aborting publish to prevent pushing invalid content to GitHub Pages."
-            exit 1
-          fi
-          echo "Report content validation passed."
+        run: python scripts/validate_report.py index.md
 
       - name: Commit and push updated report
         if: github.ref == 'refs/heads/main'

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,26 @@ Thumbs.db
 
 # Private notes (do not commit)
 docs/notes/
+
+# Private local files
+AGENTS.md
+agents.md
+AGENT.md
+agent.md
+CLAUDE.md
+claude.md
+GEMINI.md
+gemini.md
+.claude/
+.codex/
+.copilot/
+.cursor/
+.cursorrules
+.windsurf/
+.windsurfrules
+.github/copilot-instructions.md
+.github/instructions/
+agent-instructions.md
+agent_instructions.md
+assistant-instructions.md
+assistant_instructions.md

--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ Automated cybersecurity threat intelligence that monitors RSS feeds and generate
    echo "ANTHROPIC_API_KEY=your-api-key-here" > .env
    ```
 
-3. Configure feeds and output paths in `config/config.json`
+3. Configure feeds, output paths, and the default Anthropic model in `config/config.json`.
+   Override the model for a single environment with:
+   ```bash
+   export SENTRYINSIGHT_ANTHROPIC_MODEL=claude-sonnet-4-6
+   ```
 
 ## Usage
 
@@ -43,3 +47,9 @@ python main.py
 ```
 
 Fetches articles, filters for exploitation content, analyzes threats, and saves reports to `index.md`.
+
+Validate a generated report before publishing:
+
+```bash
+python scripts/validate_report.py index.md
+```

--- a/config/config.json
+++ b/config/config.json
@@ -2,7 +2,7 @@
     "feed_url": "https://ricomanifesto.github.io/SentryDigest/feed.xml",
     "output_path": "index.md",
     "analysis": {
-        "model": "claude-sonnet-4-20250514",
+        "model": "claude-sonnet-4-6",
         "max_tokens": 4000,
         "temperature": 1,
         "analysis_focus": [

--- a/main.py
+++ b/main.py
@@ -22,24 +22,32 @@ from src.core.workflow import run_exploitation_analysis
 # Import MCP server for RSS operations
 from src.services.rss_mcp import mcp_app
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.FileHandler("exploitation-analysis.log"),
-        logging.StreamHandler()
-    ]
-)
 logger = logging.getLogger(__name__)
+
+def configure_logging():
+    """Configure logging when the executable entrypoint runs."""
+    root_logger = logging.getLogger()
+    if root_logger.handlers:
+        return
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        handlers=[
+            logging.FileHandler("exploitation-analysis.log"),
+            logging.StreamHandler()
+        ]
+    )
 
 def run_mcp_server():
     """Run the MCP server in a separate thread."""
+    configure_logging()
     logger.info("Starting RSS MCP Server")
     mcp_app.run(transport="stdio")
 
 async def main():
     """Main function to run the LangGraph workflow."""
+    configure_logging()
     logger.info("Starting SentryDigest Exploitation Report Generator with LangGraph workflow")
     
     try:
@@ -48,11 +56,13 @@ async def main():
         
         if not result or result.get("status") == "failed":
             logger.error("Errors occurred during analysis")
+            raise SystemExit(1)
         else:
             logger.info("Analysis completed successfully")
             
     except Exception as e:
         logger.error(f"Error in main function: {e}")
+        raise SystemExit(1)
 
 if __name__ == "__main__":
     # Start MCP server in a separate thread if needed

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ mcp-python>=0.1.0
 anthropic
 elevenlabs
 pydub
+pytest

--- a/scripts/local_validation.sh
+++ b/scripts/local_validation.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+export PYTHONDONTWRITEBYTECODE=1
+
+python3 -B -m pytest tests -q -p no:cacheprovider
+python3 -B scripts/validate_report.py index.md

--- a/scripts/validate_report.py
+++ b/scripts/validate_report.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Validate generated report markdown before publishing."""
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.core.report_validation import (
+    format_report_validation_issues,
+    validate_report_content,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate generated exploitation report markdown."
+    )
+    parser.add_argument(
+        "report_path",
+        nargs="?",
+        default="index.md",
+        help="Path to the generated markdown report.",
+    )
+    args = parser.parse_args()
+
+    report_path = Path(args.report_path)
+    if not report_path.exists():
+        print(f"Report does not exist: {report_path}")
+        return 1
+
+    issues = validate_report_content(report_path.read_text())
+    if issues:
+        print("Report content validation failed:")
+        print(format_report_validation_issues(issues))
+        return 1
+
+    print(f"Report content validation passed: {report_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/core/analyze.py
+++ b/src/core/analyze.py
@@ -9,6 +9,8 @@ import tiktoken
 from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import HumanMessage, SystemMessage
 
+from .model_config import resolve_anthropic_model, validate_anthropic_model
+
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
@@ -75,8 +77,17 @@ async def analyze_exploitation(articles: List[Dict[str, Any]], config: Dict[str,
     
     # Initialize the AI model (Anthropic Claude)
     api_key = os.getenv("ANTHROPIC_API_KEY")
-    model_name = config.get("analysis", {}).get("model", "claude-sonnet-4-20250514")
+    model_name = resolve_anthropic_model(config)
     max_tokens = config.get("analysis", {}).get("max_tokens", 4000)
+    try:
+        validate_anthropic_model(model_name)
+    except ValueError as e:
+        logger.error(f"Invalid Anthropic model configuration: {e}")
+        return {
+            "exploitation_report": f"# Error: Invalid Anthropic Model\n\n{str(e)}",
+            "date": datetime.now().strftime("%Y-%m-%d"),
+            "error": str(e)
+        }
     
     if not api_key:
         logger.error("No Anthropic API key provided")

--- a/src/core/model_config.py
+++ b/src/core/model_config.py
@@ -1,0 +1,40 @@
+"""Anthropic model configuration helpers."""
+
+import os
+import re
+from typing import Any, Dict
+
+DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6"
+MODEL_ENV_VAR = "SENTRYINSIGHT_ANTHROPIC_MODEL"
+
+_MODEL_ID_PATTERN = re.compile(r"^claude-[a-z0-9]+(?:-[a-z0-9]+)*$")
+_KNOWN_UNAVAILABLE_MODELS = {
+    "claude-sonnet-4-20250514",
+}
+
+
+def resolve_anthropic_model(config: Dict[str, Any]) -> str:
+    """Resolve the Anthropic model from env, config, or the project default."""
+    env_model = os.getenv(MODEL_ENV_VAR, "").strip()
+    if env_model:
+        return env_model
+
+    configured_model = config.get("analysis", {}).get("model", "").strip()
+    return configured_model or DEFAULT_ANTHROPIC_MODEL
+
+
+def validate_anthropic_model(model_name: str) -> None:
+    """Raise ValueError when the configured model is known-bad or malformed."""
+    if not model_name:
+        raise ValueError("Anthropic model is empty")
+
+    if model_name in _KNOWN_UNAVAILABLE_MODELS:
+        raise ValueError(
+            f"Anthropic model {model_name!r} is known to return 404; "
+            f"use {DEFAULT_ANTHROPIC_MODEL!r} or set {MODEL_ENV_VAR}."
+        )
+
+    if not _MODEL_ID_PATTERN.match(model_name):
+        raise ValueError(
+            f"Anthropic model {model_name!r} is not a valid Claude API model ID"
+        )

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -1,0 +1,71 @@
+"""Validation rules for generated exploitation reports."""
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+REQUIRED_SECTIONS = (
+    "# Exploitation Report",
+    "## Active Exploitation Details",
+    "## Affected Systems and Products",
+    "## Attack Vectors and Techniques",
+    "## Threat Actor Activities",
+)
+
+ERROR_MARKERS = (
+    "# Error",
+    "Error code:",
+    "Error Generating Exploitation Report",
+    "No Anthropic API Key",
+    "credit balance is too low",
+    "authentication_error",
+    "not_found_error",
+    "rate_limit_error",
+    "overloaded_error",
+)
+
+
+@dataclass(frozen=True)
+class ReportValidationIssue:
+    code: str
+    message: str
+
+
+def validate_report_content(markdown: str) -> List[ReportValidationIssue]:
+    """Return validation issues that should block publishing."""
+    issues: List[ReportValidationIssue] = []
+    content = markdown.strip()
+
+    if not content:
+        return [
+            ReportValidationIssue(
+                code="empty_report",
+                message="Report is empty.",
+            )
+        ]
+
+    for marker in ERROR_MARKERS:
+        if marker in content:
+            issues.append(
+                ReportValidationIssue(
+                    code="error_marker",
+                    message=f"Report contains blocked error marker: {marker}",
+                )
+            )
+
+    for section in REQUIRED_SECTIONS:
+        if section not in content:
+            issues.append(
+                ReportValidationIssue(
+                    code="missing_section",
+                    message=f"Report is missing required section: {section}",
+                )
+            )
+
+    return issues
+
+
+def format_report_validation_issues(
+    issues: Iterable[ReportValidationIssue],
+) -> str:
+    """Format validation issues for logs and CLI output."""
+    return "\n".join(f"- {issue.code}: {issue.message}" for issue in issues)

--- a/src/core/workflow.py
+++ b/src/core/workflow.py
@@ -9,6 +9,10 @@ from pathlib import Path
 
 from ..services.rss_mcp import fetch_rss_feed, enrich_rss_articles  # Import the MCP tools
 from .analyze import filter_exploitation_articles, analyze_exploitation
+from .report_validation import (
+    format_report_validation_issues,
+    validate_report_content,
+)
 from ..services.publish import publish_to_github_pages
 from ..services.audio import (
     generate_executive_summary_audio,
@@ -119,6 +123,9 @@ async def analyze_articles(state: ExploitationAnalysisState) -> ExploitationAnal
     # Analyze the filtered articles
     analysis_results = await analyze_exploitation(filtered_articles, config)
     state["analysis_results"] = analysis_results
+    if analysis_results.get("error"):
+        logger.error(f"Analysis failed: {analysis_results['error']}")
+        state["status"] = "failed"
     
     logger.info("Completed article analysis")
     return state
@@ -141,6 +148,17 @@ async def generate_report(state: ExploitationAnalysisState) -> ExploitationAnaly
     # Since the exploitation_report already contains the full formatted report,
     # we should use it directly instead of the template
     report = exploitation_report
+    validation_issues = validate_report_content(report)
+    if validation_issues:
+        logger.error(
+            "Report validation failed:\n%s",
+            format_report_validation_issues(validation_issues),
+        )
+        state["report_validation_errors"] = [
+            issue.message for issue in validation_issues
+        ]
+        state["status"] = "failed"
+        return state
     
     # Save the report
     output_path = config.get("output_path", "index.md")
@@ -162,6 +180,10 @@ async def generate_audio(state: ExploitationAnalysisState) -> ExploitationAnalys
     """Generate audio narration of the executive summary using Eleven Labs."""
     logger.info("Generating executive summary audio")
 
+    if state.get("status") == "failed":
+        logger.warning("Skipping audio generation because report generation failed")
+        return state
+
     analysis_results = state.get("analysis_results", {})
     report = analysis_results.get("exploitation_report", "")
 
@@ -182,6 +204,10 @@ async def generate_audio(state: ExploitationAnalysisState) -> ExploitationAnalys
 async def publish_results(state: ExploitationAnalysisState) -> ExploitationAnalysisState:
     """Publish results to GitHub Pages or local file"""
     logger.info("Publishing results")
+
+    if state.get("status") == "failed":
+        logger.warning("Skipping publishing because workflow status is failed")
+        return state
     
     config = state["config"]
     analysis_results = state["analysis_results"]

--- a/src/services/publish.py
+++ b/src/services/publish.py
@@ -4,6 +4,11 @@ from pathlib import Path
 from datetime import datetime
 from typing import Dict, Any
 
+from src.core.report_validation import (
+    format_report_validation_issues,
+    validate_report_content,
+)
+
 # Set up logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
@@ -37,6 +42,13 @@ async def publish_to_github_pages(
         # Extract the exploitation report and date
         exploitation_report = analysis_results.get("exploitation_report", "No exploitation report available.")
         report_date = analysis_results.get("date", datetime.now().strftime("%Y-%m-%d"))
+        validation_issues = validate_report_content(exploitation_report)
+        if validation_issues:
+            logger.error(
+                "Refusing to publish invalid report:\n%s",
+                format_report_validation_issues(validation_issues),
+            )
+            return False
         
         # Create the main index.html file
         index_path = repo_path / "index.md"

--- a/tests/test_analyze_guards.py
+++ b/tests/test_analyze_guards.py
@@ -1,0 +1,81 @@
+import asyncio
+import importlib
+import os
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+
+def import_analyze_with_stubs():
+    sys.modules.pop("src.core.analyze", None)
+
+    tiktoken_module = types.ModuleType("tiktoken")
+    tiktoken_module.get_encoding = lambda _name: types.SimpleNamespace(
+        encode=lambda value: value.split()
+    )
+
+    anthropic_module = types.ModuleType("langchain_anthropic")
+
+    class ChatAnthropic:
+        def __init__(self, **_kwargs):
+            raise AssertionError("ChatAnthropic should not be constructed")
+
+    anthropic_module.ChatAnthropic = ChatAnthropic
+
+    messages_module = types.ModuleType("langchain_core.messages")
+    messages_module.HumanMessage = lambda content: types.SimpleNamespace(
+        content=content
+    )
+    messages_module.SystemMessage = lambda content: types.SimpleNamespace(
+        content=content
+    )
+
+    with patch.dict(
+        sys.modules,
+        {
+            "tiktoken": tiktoken_module,
+            "langchain_anthropic": anthropic_module,
+            "langchain_core.messages": messages_module,
+        },
+    ):
+        return importlib.import_module("src.core.analyze")
+
+
+class AnalyzeGuardTests(unittest.TestCase):
+    def test_invalid_model_returns_error_before_external_call(self):
+        analyze = import_analyze_with_stubs()
+
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
+            result = asyncio.run(
+                analyze.analyze_exploitation(
+                    articles=[],
+                    config={
+                        "analysis": {
+                            "model": "claude-sonnet-4-20250514",
+                        }
+                    },
+                )
+            )
+
+        self.assertIn("error", result)
+        self.assertIn("known to return 404", result["error"])
+        self.assertIn("# Error: Invalid Anthropic Model", result["exploitation_report"])
+
+    def test_missing_api_key_returns_error_without_external_call(self):
+        analyze = import_analyze_with_stubs()
+
+        with patch.dict(os.environ, {}, clear=True):
+            result = asyncio.run(
+                analyze.analyze_exploitation(
+                    articles=[],
+                    config={"analysis": {"model": "claude-sonnet-4-6"}},
+                )
+            )
+
+        self.assertEqual(result["error"], "No API key")
+        self.assertIn("No Anthropic API Key", result["exploitation_report"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_main_exit.py
+++ b/tests/test_main_exit.py
@@ -1,0 +1,58 @@
+import asyncio
+import importlib
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+
+def import_main_with_workflow(result=None, error=None):
+    sys.modules.pop("main", None)
+
+    workflow_module = types.ModuleType("src.core.workflow")
+
+    async def run_exploitation_analysis():
+        if error:
+            raise error
+        return result
+
+    workflow_module.run_exploitation_analysis = run_exploitation_analysis
+
+    rss_module = types.ModuleType("src.services.rss_mcp")
+    rss_module.mcp_app = types.SimpleNamespace(run=lambda **_kwargs: None)
+
+    with patch.dict(
+        sys.modules,
+        {
+            "src.core.workflow": workflow_module,
+            "src.services.rss_mcp": rss_module,
+        },
+    ):
+        return importlib.import_module("main")
+
+
+class MainExitTests(unittest.TestCase):
+    def test_failed_workflow_exits_nonzero(self):
+        main_module = import_main_with_workflow(result={"status": "failed"})
+
+        with self.assertRaises(SystemExit) as context:
+            asyncio.run(main_module.main())
+
+        self.assertEqual(context.exception.code, 1)
+
+    def test_workflow_exception_exits_nonzero(self):
+        main_module = import_main_with_workflow(error=RuntimeError("boom"))
+
+        with self.assertRaises(SystemExit) as context:
+            asyncio.run(main_module.main())
+
+        self.assertEqual(context.exception.code, 1)
+
+    def test_successful_workflow_does_not_exit(self):
+        main_module = import_main_with_workflow(result={"status": "completed"})
+
+        asyncio.run(main_module.main())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -1,0 +1,39 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from src.core.model_config import (
+    DEFAULT_ANTHROPIC_MODEL,
+    MODEL_ENV_VAR,
+    resolve_anthropic_model,
+    validate_anthropic_model,
+)
+
+
+class ModelConfigTests(unittest.TestCase):
+    def test_resolves_model_from_config(self):
+        config = {"analysis": {"model": "claude-sonnet-4-6"}}
+
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(resolve_anthropic_model(config), "claude-sonnet-4-6")
+
+    def test_env_override_wins(self):
+        config = {"analysis": {"model": "claude-haiku-4-5"}}
+
+        with patch.dict(os.environ, {MODEL_ENV_VAR: "claude-opus-4-8"}):
+            self.assertEqual(resolve_anthropic_model(config), "claude-opus-4-8")
+
+    def test_empty_config_uses_default(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(resolve_anthropic_model({}), DEFAULT_ANTHROPIC_MODEL)
+
+    def test_rejects_known_unavailable_model(self):
+        with self.assertRaises(ValueError):
+            validate_anthropic_model("claude-sonnet-4-20250514")
+
+    def test_accepts_current_dateless_model(self):
+        validate_anthropic_model("claude-sonnet-4-6")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_publish_guards.py
+++ b/tests/test_publish_guards.py
@@ -1,0 +1,75 @@
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.services.publish import publish_to_github_pages
+
+
+VALID_REPORT = """# Exploitation Report
+
+Recent exploitation activity is concentrated in edge systems.
+
+## Active Exploitation Details
+
+### Example Vulnerability
+- **Description**: Attackers are exploiting a vulnerable service.
+- **Impact**: Remote access.
+- **Status**: Active exploitation observed.
+
+## Affected Systems and Products
+
+- **Example Product**: Affected versions are exposed.
+
+## Attack Vectors and Techniques
+
+- **Internet-facing service**: Attackers send crafted requests.
+
+## Threat Actor Activities
+
+- **Unknown actor**: Opportunistic exploitation.
+"""
+
+
+class PublishGuardTests(unittest.TestCase):
+    def test_invalid_report_is_not_written_to_pages_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_dir = Path(tmpdir) / "docs"
+            result = asyncio.run(
+                publish_to_github_pages(
+                    {
+                        "exploitation_report": (
+                            "# Error Generating Exploitation Report\n\n"
+                            "Error code: 404"
+                        ),
+                        "date": "2026-06-17",
+                    },
+                    {"enabled": True, "repo_directory": str(repo_dir)},
+                )
+            )
+
+            self.assertFalse(result)
+            self.assertTrue(repo_dir.exists())
+            self.assertFalse((repo_dir / "index.md").exists())
+
+    def test_valid_report_writes_pages_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_dir = Path(tmpdir) / "docs"
+            result = asyncio.run(
+                publish_to_github_pages(
+                    {
+                        "exploitation_report": VALID_REPORT,
+                        "date": "2026-06-17",
+                    },
+                    {"enabled": True, "repo_directory": str(repo_dir)},
+                )
+            )
+
+            self.assertTrue(result)
+            self.assertIn(VALID_REPORT, (repo_dir / "index.md").read_text())
+            self.assertTrue((repo_dir / "navigation.md").exists())
+            self.assertTrue((repo_dir / "_config.yml").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -1,0 +1,54 @@
+import unittest
+
+from src.core.report_validation import validate_report_content
+
+
+VALID_REPORT = """# Exploitation Report
+
+Recent exploitation activity is concentrated in edge systems.
+
+## Active Exploitation Details
+
+### Example Vulnerability
+- **Description**: Attackers are exploiting a vulnerable service.
+- **Impact**: Remote access.
+- **Status**: Active exploitation observed.
+
+## Affected Systems and Products
+
+- **Example Product**: Affected versions are exposed.
+
+## Attack Vectors and Techniques
+
+- **Internet-facing service**: Attackers send crafted requests.
+
+## Threat Actor Activities
+
+- **Unknown actor**: Opportunistic exploitation.
+"""
+
+
+class ReportValidationTests(unittest.TestCase):
+    def test_valid_report_passes(self):
+        self.assertEqual(validate_report_content(VALID_REPORT), [])
+
+    def test_api_error_marker_fails(self):
+        issues = validate_report_content(
+            "# Error Generating Exploitation Report\n\nError code: 404"
+        )
+
+        self.assertTrue(any(issue.code == "error_marker" for issue in issues))
+
+    def test_missing_required_section_fails(self):
+        issues = validate_report_content("# Exploitation Report\n\nSummary only")
+
+        self.assertTrue(any(issue.code == "missing_section" for issue in issues))
+
+    def test_empty_report_fails(self):
+        issues = validate_report_content("")
+
+        self.assertEqual(issues[0].code, "empty_report")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workflow_guards.py
+++ b/tests/test_workflow_guards.py
@@ -1,0 +1,141 @@
+import asyncio
+import importlib
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+def import_workflow_with_stubs(analysis_result=None):
+    sys.modules.pop("src.core.workflow", None)
+
+    graph_module = types.ModuleType("langgraph.graph")
+    graph_module.START = "START"
+    graph_module.END = "END"
+
+    class StateGraph:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def add_node(self, *_args, **_kwargs):
+            pass
+
+        def add_edge(self, *_args, **_kwargs):
+            pass
+
+        def add_conditional_edges(self, *_args, **_kwargs):
+            pass
+
+        def compile(self):
+            return self
+
+    graph_module.StateGraph = StateGraph
+
+    langgraph_module = types.ModuleType("langgraph")
+    langgraph_module.graph = graph_module
+
+    rss_module = types.ModuleType("src.services.rss_mcp")
+    rss_module.fetch_rss_feed = None
+    rss_module.enrich_rss_articles = None
+
+    analyze_module = types.ModuleType("src.core.analyze")
+    analyze_module.filter_exploitation_articles = lambda articles: articles
+
+    async def analyze_exploitation(_articles, _config):
+        return analysis_result or {}
+
+    analyze_module.analyze_exploitation = analyze_exploitation
+
+    publish_module = types.ModuleType("src.services.publish")
+
+    async def publish_to_github_pages(_analysis_results, _github_pages_config):
+        raise AssertionError("publish should not run for failed state")
+
+    publish_module.publish_to_github_pages = publish_to_github_pages
+
+    audio_module = types.ModuleType("src.services.audio")
+
+    async def generate_executive_summary_audio(_report, _output_path):
+        raise AssertionError("audio generation should not run for failed state")
+
+    audio_module.generate_executive_summary_audio = generate_executive_summary_audio
+
+    with patch.dict(
+        sys.modules,
+        {
+            "langgraph": langgraph_module,
+            "langgraph.graph": graph_module,
+            "src.services.rss_mcp": rss_module,
+            "src.core.analyze": analyze_module,
+            "src.services.publish": publish_module,
+            "src.services.audio": audio_module,
+        },
+    ):
+        return importlib.import_module("src.core.workflow")
+
+
+class WorkflowGuardTests(unittest.TestCase):
+    def test_analysis_error_marks_state_failed(self):
+        workflow = import_workflow_with_stubs(analysis_result={"error": "bad model"})
+        state = {
+            "filtered_articles": [{"title": "Example"}],
+            "analysis_results": {},
+            "config": {},
+            "status": "started",
+        }
+
+        result = asyncio.run(workflow.analyze_articles(state))
+
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(result["analysis_results"]["error"], "bad model")
+
+    def test_invalid_report_does_not_write_output_file(self):
+        workflow = import_workflow_with_stubs()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "index.md"
+            state = {
+                "analysis_results": {
+                    "exploitation_report": (
+                        "# Error Generating Exploitation Report\n\n"
+                        "Error code: 404"
+                    )
+                },
+                "config": {"output_path": str(output_path)},
+                "status": "started",
+            }
+
+            result = asyncio.run(workflow.generate_report(state))
+
+            self.assertEqual(result["status"], "failed")
+            self.assertIn("report_validation_errors", result)
+            self.assertFalse(output_path.exists())
+
+    def test_failed_state_skips_audio_generation(self):
+        workflow = import_workflow_with_stubs()
+        state = {
+            "analysis_results": {"exploitation_report": "# Exploitation Report"},
+            "status": "failed",
+        }
+
+        result = asyncio.run(workflow.generate_audio(state))
+
+        self.assertIs(result, state)
+
+    def test_failed_state_skips_publish(self):
+        workflow = import_workflow_with_stubs()
+        state = {
+            "analysis_results": {"exploitation_report": "# Exploitation Report"},
+            "config": {"github_pages": {"enabled": True}},
+            "status": "failed",
+        }
+
+        result = asyncio.run(workflow.publish_results(state))
+
+        self.assertIs(result, state)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add model resolution and validation before report generation.
- Block invalid or error-filled reports before audio generation, publish, or workflow commit.
- Add a local validation script and focused tests for model config, report guards, publish guards, and main exit behavior.

## Motivation
A bad model value or API error can produce broken report content. The new guards fail early and keep invalid output out of the public report path.

## Validation
- `bash scripts/local_validation.sh`