### PR TITLE
Route report generation through OpenCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ Automated cybersecurity threat intelligence that monitors RSS feeds and generate
 
 - **LangGraph**: Orchestrates workflow state and conditional logic
 - **FastMCP**: Code organization with decorators for RSS tools
-- **LangChain**: AI model integration and text processing
-- **Anthropic Claude**: Content analysis and report generation
+- **OpenCode**: Provider-switchable report generation
 
 ## Setup
 
@@ -29,15 +28,20 @@ Automated cybersecurity threat intelligence that monitors RSS feeds and generate
    uv sync --group dev
    ```
 
-2. Add Anthropic API key:
+2. Start an OpenCode server with access to your preferred model provider:
    ```bash
-   echo "ANTHROPIC_API_KEY=your-api-key-here" > .env
+   opencode serve --port 4096
    ```
 
-3. Configure feeds, output paths, and the default Anthropic model in `config/config.json`.
-   Override the model for a single environment with:
+3. Configure feeds, output paths, and the default model in `config/config.json`.
+   Model IDs use `provider/model` format. Override the model for one
+   environment with:
    ```bash
-   export SENTRYINSIGHT_ANTHROPIC_MODEL=claude-sonnet-4-6
+   export SENTRYINSIGHT_MODEL=anthropic/claude-sonnet-4-6
+   ```
+   If OpenCode is not listening on `http://127.0.0.1:4096`, set:
+   ```bash
+   export OPENCODE_BASE_URL=http://127.0.0.1:4096
    ```
 
 ## Usage

--- a/config/config.json
+++ b/config/config.json
@@ -2,7 +2,7 @@
     "feed_url": "https://ricomanifesto.github.io/SentryDigest/feed.xml",
     "output_path": "index.md",
     "analysis": {
-        "model": "claude-sonnet-4-6",
+        "model": "anthropic/claude-sonnet-4-6",
         "max_tokens": 4000,
         "temperature": 1,
         "analysis_focus": [

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     pass
 
-# Anthropic API key should be set via environment variable ANTHROPIC_API_KEY
+# OpenCode should be running with access to the configured model provider.
 
 # Import the LangGraph workflow
 from src.core.workflow import run_exploitation_analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,10 @@ description = "Automated cybersecurity threat intelligence report generation"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "anthropic",
     "elevenlabs",
     "feedparser",
     "httpx",
     "langchain>=0.1.0",
-    "langchain-anthropic",
     "langchain-core",
     "langgraph>=0.0.20",
     "mcp-python>=0.1.0",

--- a/src/core/analyze.py
+++ b/src/core/analyze.py
@@ -1,14 +1,11 @@
 import logging
-import os
 from typing import List, Dict, Any
 from datetime import datetime
 
 import tiktoken
-from langchain_anthropic import ChatAnthropic
-from langchain_core.messages import HumanMessage, SystemMessage
-from pydantic import SecretStr
 
-from .model_config import resolve_anthropic_model, validate_anthropic_model
+from .model_config import resolve_model, validate_model
+from .opencode_client import OpenCodeClient, parse_model_selection
 
 # Configure logging
 logging.basicConfig(
@@ -87,33 +84,19 @@ async def analyze_exploitation(
     """
     logger.info(f"Analyzing exploitation in {len(articles)} articles")
 
-    # Initialize the AI model (Anthropic Claude)
-    api_key = os.getenv("ANTHROPIC_API_KEY")
-    model_name = resolve_anthropic_model(config)
+    # Initialize the AI model through OpenCode.
+    model_name = resolve_model(config)
     max_tokens = int(config.get("analysis", {}).get("max_tokens", 4000))
     try:
-        validate_anthropic_model(model_name)
+        validate_model(model_name)
+        model_selection = parse_model_selection(model_name)
     except ValueError as e:
-        logger.error(f"Invalid Anthropic model configuration: {e}")
+        logger.error(f"Invalid model configuration: {e}")
         return {
-            "exploitation_report": f"# Error: Invalid Anthropic Model\n\n{str(e)}",
+            "exploitation_report": f"# Error: Invalid Model\n\n{str(e)}",
             "date": datetime.now().strftime("%Y-%m-%d"),
             "error": str(e),
         }
-
-    if not api_key:
-        logger.error("No Anthropic API key provided")
-        return {
-            "exploitation_report": "# Error: No Anthropic API Key\n\nPlease set the ANTHROPIC_API_KEY environment variable.",
-            "date": datetime.now().strftime("%Y-%m-%d"),
-            "error": "No API key",
-        }
-
-    model = ChatAnthropic(
-        api_key=SecretStr(api_key),
-        model_name=model_name,
-        max_tokens_to_sample=max_tokens,
-    )
 
     # Prepare all article summaries
     all_article_summaries = []
@@ -217,17 +200,13 @@ Generate a well-formatted exploitation report following the structure above. Be 
 
     # Call the AI model
     try:
-        messages = [
-            SystemMessage(
-                content="You are a cybersecurity threat hunter specializing in vulnerability exploitation analysis. Your task is to create a comprehensive report on current exploit activity based on recent security articles. Be extremely thorough in identifying ALL exploited vulnerabilities mentioned in the articles, including zero-days, active exploits, and recently patched vulnerabilities that were exploited in the wild."
-            ),
-            HumanMessage(content=prompt),
-        ]
-
-        response = await model.ainvoke(messages)
-
-        # Extract the exploitation report
-        exploitation_report = response.content
+        client = OpenCodeClient(timeout=max(120.0, float(max_tokens) / 20))
+        exploitation_report = await client.generate(
+            system_prompt="You are a cybersecurity threat hunter specializing in vulnerability exploitation analysis. Your task is to create a comprehensive report on current exploit activity based on recent security articles. Be extremely thorough in identifying ALL exploited vulnerabilities mentioned in the articles, including zero-days, active exploits, and recently patched vulnerabilities that were exploited in the wild.",
+            user_prompt=prompt,
+            model=model_selection,
+            title="SentryInsight exploitation report",
+        )
 
         return {
             "exploitation_report": exploitation_report,

--- a/src/core/model_config.py
+++ b/src/core/model_config.py
@@ -1,40 +1,41 @@
-"""Anthropic model configuration helpers."""
+"""Model configuration helpers."""
 
 import os
 import re
 from typing import Any, Dict
 
-DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6"
-MODEL_ENV_VAR = "SENTRYINSIGHT_ANTHROPIC_MODEL"
+DEFAULT_MODEL = "anthropic/claude-sonnet-4-6"
+MODEL_ENV_VAR = "SENTRYINSIGHT_MODEL"
 
-_MODEL_ID_PATTERN = re.compile(r"^claude-[a-z0-9]+(?:-[a-z0-9]+)*$")
+_MODEL_ID_PATTERN = re.compile(
+    r"^[a-z][a-z0-9_-]*/[a-z][a-z0-9._-]*(?:-[a-z0-9._-]+)*$"
+)
 _KNOWN_UNAVAILABLE_MODELS = {
     "claude-sonnet-4-20250514",
 }
 
 
-def resolve_anthropic_model(config: Dict[str, Any]) -> str:
-    """Resolve the Anthropic model from env, config, or the project default."""
+def resolve_model(config: Dict[str, Any]) -> str:
+    """Resolve the model from env, config, or the project default."""
     env_model = os.getenv(MODEL_ENV_VAR, "").strip()
     if env_model:
         return env_model
 
     configured_model = config.get("analysis", {}).get("model", "").strip()
-    return configured_model or DEFAULT_ANTHROPIC_MODEL
+    return configured_model or DEFAULT_MODEL
 
 
-def validate_anthropic_model(model_name: str) -> None:
+def validate_model(model_name: str) -> None:
     """Raise ValueError when the configured model is known-bad or malformed."""
     if not model_name:
-        raise ValueError("Anthropic model is empty")
+        raise ValueError("Model is empty")
 
-    if model_name in _KNOWN_UNAVAILABLE_MODELS:
+    model_id = model_name.split("/", 1)[-1]
+    if model_id in _KNOWN_UNAVAILABLE_MODELS:
         raise ValueError(
-            f"Anthropic model {model_name!r} is known to return 404; "
-            f"use {DEFAULT_ANTHROPIC_MODEL!r} or set {MODEL_ENV_VAR}."
+            f"Model {model_name!r} is known to return 404; "
+            f"use a current model or set {MODEL_ENV_VAR}."
         )
 
     if not _MODEL_ID_PATTERN.match(model_name):
-        raise ValueError(
-            f"Anthropic model {model_name!r} is not a valid Claude API model ID"
-        )
+        raise ValueError(f"Model {model_name!r} is not a valid provider/model ID")

--- a/src/core/opencode_client.py
+++ b/src/core/opencode_client.py
@@ -1,0 +1,138 @@
+"""OpenCode-backed model client for report generation."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+DEFAULT_OPENCODE_BASE_URL = "http://127.0.0.1:4096"
+OPENCODE_BASE_URL_ENV_VAR = "OPENCODE_BASE_URL"
+OPENCODE_SERVER_USERNAME_ENV_VAR = "OPENCODE_SERVER_USERNAME"
+OPENCODE_SERVER_PASSWORD_ENV_VAR = "OPENCODE_SERVER_PASSWORD"
+
+
+class OpenCodeError(RuntimeError):
+    """Raised when OpenCode cannot return usable model output."""
+
+
+@dataclass(frozen=True)
+class ModelSelection:
+    """Provider and model IDs accepted by the OpenCode message API."""
+
+    provider_id: str
+    model_id: str
+
+    def as_payload(self) -> dict[str, str]:
+        return {"providerID": self.provider_id, "modelID": self.model_id}
+
+
+def resolve_opencode_base_url() -> str:
+    """Return the configured OpenCode server URL."""
+    return os.getenv(OPENCODE_BASE_URL_ENV_VAR, DEFAULT_OPENCODE_BASE_URL).rstrip("/")
+
+
+def parse_model_selection(model_name: str) -> ModelSelection | None:
+    """Parse an explicit provider/model value."""
+    model_name = model_name.strip()
+    if not model_name:
+        return None
+
+    if "/" not in model_name:
+        raise ValueError("Model must use provider/model format")
+
+    provider_id, model_id = model_name.split("/", 1)
+    if provider_id and model_id:
+        return ModelSelection(provider_id=provider_id, model_id=model_id)
+    raise ValueError("Model must use provider/model format")
+
+
+class OpenCodeClient:
+    """Small HTTP client for OpenCode's session message API."""
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        timeout: float = 120.0,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self.base_url = (base_url or resolve_opencode_base_url()).rstrip("/")
+        self.timeout = timeout
+        self.transport = transport
+
+    async def generate(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        model: ModelSelection | None = None,
+        title: str = "Report generation",
+    ) -> str:
+        """Generate text through an OpenCode server session."""
+        auth = self._auth()
+        async with httpx.AsyncClient(
+            base_url=self.base_url,
+            timeout=self.timeout,
+            transport=self.transport,
+            auth=auth,
+        ) as client:
+            session_response = await client.post("/session", json={"title": title})
+            self._raise_for_status(session_response, "create OpenCode session")
+            session_id = session_response.json().get("id")
+            if not session_id:
+                raise OpenCodeError("OpenCode did not return a session id")
+
+            body: dict[str, Any] = {
+                "system": system_prompt,
+                "parts": [{"type": "text", "text": user_prompt}],
+            }
+            if model is not None:
+                body["model"] = model.as_payload()
+
+            message_response = await client.post(
+                f"/session/{session_id}/message",
+                json=body,
+            )
+            self._raise_for_status(message_response, "generate OpenCode message")
+            return self._extract_text(message_response.json())
+
+    def _auth(self) -> tuple[str, str] | None:
+        password = os.getenv(OPENCODE_SERVER_PASSWORD_ENV_VAR, "")
+        if not password:
+            return None
+        username = os.getenv(OPENCODE_SERVER_USERNAME_ENV_VAR, "opencode")
+        return (username, password)
+
+    def _raise_for_status(self, response: httpx.Response, action: str) -> None:
+        if response.is_success:
+            return
+        raise OpenCodeError(
+            f"Failed to {action}: HTTP {response.status_code} {response.text}"
+        )
+
+    def _extract_text(self, payload: dict[str, Any]) -> str:
+        parts = payload.get("parts", [])
+        text_parts: list[str] = []
+        for part in parts:
+            if not isinstance(part, dict):
+                continue
+            text = part.get("text")
+            if isinstance(text, str) and text.strip():
+                text_parts.append(text)
+                continue
+            content = part.get("content")
+            if isinstance(content, str) and content.strip():
+                text_parts.append(content)
+
+        if text_parts:
+            return "\n".join(text_parts)
+
+        info = payload.get("info", {})
+        if isinstance(info, dict):
+            text = info.get("text") or info.get("content")
+            if isinstance(text, str) and text.strip():
+                return text
+
+        raise OpenCodeError("OpenCode response did not include text output")

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -15,7 +15,7 @@ ERROR_MARKERS = (
     "# Error",
     "Error code:",
     "Error Generating Exploitation Report",
-    "No Anthropic API Key",
+    "Invalid Model",
     "credit balance is too low",
     "authentication_error",
     "not_found_error",

--- a/tests/test_analyze_guards.py
+++ b/tests/test_analyze_guards.py
@@ -15,28 +15,10 @@ def import_analyze_with_stubs():
         encode=lambda value: value.split()
     )
 
-    anthropic_module = types.ModuleType("langchain_anthropic")
-
-    class ChatAnthropic:
-        def __init__(self, **_kwargs):
-            raise AssertionError("ChatAnthropic should not be constructed")
-
-    anthropic_module.ChatAnthropic = ChatAnthropic
-
-    messages_module = types.ModuleType("langchain_core.messages")
-    messages_module.HumanMessage = lambda content: types.SimpleNamespace(
-        content=content
-    )
-    messages_module.SystemMessage = lambda content: types.SimpleNamespace(
-        content=content
-    )
-
     with patch.dict(
         sys.modules,
         {
             "tiktoken": tiktoken_module,
-            "langchain_anthropic": anthropic_module,
-            "langchain_core.messages": messages_module,
         },
     ):
         return importlib.import_module("src.core.analyze")
@@ -46,13 +28,13 @@ class AnalyzeGuardTests(unittest.TestCase):
     def test_invalid_model_returns_error_before_external_call(self):
         analyze = import_analyze_with_stubs()
 
-        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
+        with patch.dict(os.environ, {}, clear=True):
             result = asyncio.run(
                 analyze.analyze_exploitation(
                     articles=[],
                     config={
                         "analysis": {
-                            "model": "claude-sonnet-4-20250514",
+                            "model": "anthropic/claude-sonnet-4-20250514",
                         }
                     },
                 )
@@ -60,21 +42,33 @@ class AnalyzeGuardTests(unittest.TestCase):
 
         self.assertIn("error", result)
         self.assertIn("known to return 404", result["error"])
-        self.assertIn("# Error: Invalid Anthropic Model", result["exploitation_report"])
+        self.assertIn("# Error: Invalid Model", result["exploitation_report"])
 
-    def test_missing_api_key_returns_error_without_external_call(self):
+    def test_generates_report_through_opencode_without_provider_api_key(self):
         analyze = import_analyze_with_stubs()
+
+        class FakeOpenCodeClient:
+            def __init__(self, **_kwargs):
+                pass
+
+            async def generate(self, **kwargs):
+                self.kwargs = kwargs
+                assert kwargs["model"].provider_id == "anthropic"
+                assert kwargs["model"].model_id == "claude-sonnet-4-6"
+                return "# Exploitation Report\n\nGenerated through OpenCode."
+
+        analyze.OpenCodeClient = FakeOpenCodeClient
 
         with patch.dict(os.environ, {}, clear=True):
             result = asyncio.run(
                 analyze.analyze_exploitation(
                     articles=[],
-                    config={"analysis": {"model": "claude-sonnet-4-6"}},
+                    config={"analysis": {"model": "anthropic/claude-sonnet-4-6"}},
                 )
             )
 
-        self.assertEqual(result["error"], "No API key")
-        self.assertIn("No Anthropic API Key", result["exploitation_report"])
+        self.assertNotIn("error", result)
+        self.assertIn("Generated through OpenCode", result["exploitation_report"])
 
 
 if __name__ == "__main__":

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -3,36 +3,47 @@ import unittest
 from unittest.mock import patch
 
 from src.core.model_config import (
-    DEFAULT_ANTHROPIC_MODEL,
+    DEFAULT_MODEL,
     MODEL_ENV_VAR,
-    resolve_anthropic_model,
-    validate_anthropic_model,
+    resolve_model,
+    validate_model,
 )
+from src.core.opencode_client import parse_model_selection
 
 
 class ModelConfigTests(unittest.TestCase):
     def test_resolves_model_from_config(self):
-        config = {"analysis": {"model": "claude-sonnet-4-6"}}
+        config = {"analysis": {"model": "anthropic/claude-sonnet-4-6"}}
 
         with patch.dict(os.environ, {}, clear=True):
-            self.assertEqual(resolve_anthropic_model(config), "claude-sonnet-4-6")
+            self.assertEqual(resolve_model(config), "anthropic/claude-sonnet-4-6")
 
     def test_env_override_wins(self):
-        config = {"analysis": {"model": "claude-haiku-4-5"}}
+        config = {"analysis": {"model": "anthropic/claude-haiku-4-5"}}
 
-        with patch.dict(os.environ, {MODEL_ENV_VAR: "claude-opus-4-8"}):
-            self.assertEqual(resolve_anthropic_model(config), "claude-opus-4-8")
+        with patch.dict(os.environ, {MODEL_ENV_VAR: "openai/gpt-5"}):
+            self.assertEqual(resolve_model(config), "openai/gpt-5")
 
     def test_empty_config_uses_default(self):
         with patch.dict(os.environ, {}, clear=True):
-            self.assertEqual(resolve_anthropic_model({}), DEFAULT_ANTHROPIC_MODEL)
+            self.assertEqual(resolve_model({}), DEFAULT_MODEL)
 
     def test_rejects_known_unavailable_model(self):
         with self.assertRaises(ValueError):
-            validate_anthropic_model("claude-sonnet-4-20250514")
+            validate_model("anthropic/claude-sonnet-4-20250514")
 
-    def test_accepts_current_dateless_model(self):
-        validate_anthropic_model("claude-sonnet-4-6")
+    def test_accepts_provider_model(self):
+        validate_model("openai/gpt-5")
+
+    def test_rejects_bare_provider_model(self):
+        with self.assertRaises(ValueError):
+            validate_model("claude-sonnet-4-6")
+
+    def test_parses_explicit_provider_model(self):
+        model = parse_model_selection("anthropic/claude-sonnet-4-6")
+
+        self.assertEqual(model.provider_id, "anthropic")
+        self.assertEqual(model.model_id, "claude-sonnet-4-6")
 
 
 if __name__ == "__main__":

--- a/tests/test_opencode_client.py
+++ b/tests/test_opencode_client.py
@@ -1,0 +1,54 @@
+import asyncio
+import json
+import unittest
+
+import httpx
+
+from src.core.opencode_client import OpenCodeClient, parse_model_selection
+
+
+class OpenCodeClientTests(unittest.TestCase):
+    def test_generate_posts_session_message_with_model(self):
+        requests = []
+
+        def handler(request):
+            requests.append(request)
+            if request.url.path == "/session":
+                return httpx.Response(200, json={"id": "session-1"})
+            if request.url.path == "/session/session-1/message":
+                payload = json.loads(request.content.decode())
+                self.assertEqual(
+                    payload["model"],
+                    {"providerID": "openai", "modelID": "gpt-5"},
+                )
+                return httpx.Response(
+                    200,
+                    json={
+                        "info": {"id": "message-1"},
+                        "parts": [{"type": "text", "text": "Generated report"}],
+                    },
+                )
+            return httpx.Response(404)
+
+        client = OpenCodeClient(
+            base_url="http://opencode.test",
+            transport=httpx.MockTransport(handler),
+        )
+
+        result = asyncio.run(
+            client.generate(
+                system_prompt="system",
+                user_prompt="user",
+                model=parse_model_selection("openai/gpt-5"),
+            )
+        )
+
+        self.assertEqual(result, "Generated report")
+        self.assertEqual(
+            [request.url.path for request in requests],
+            ["/session", "/session/session-1/message"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -18,25 +18,6 @@ wheels = [
 ]
 
 [[package]]
-name = "anthropic"
-version = "0.109.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "docstring-parser" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/b7/9a8e2f79011e89dd6eeb599c27332aed765dac9d6fbee3a55e68e4e3ec25/anthropic-0.109.2.tar.gz", hash = "sha256:d37db299597c7bc124b49b767ff135f1e6456b64af2b2fad4b63b2a1df333cf0", size = 927559 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/f2/bee5de8a2699fc8a3cce34d61c7a2626a2c310ddde7ea5611327eb0ddbe9/anthropic-0.109.2-py3-none-any.whl", hash = "sha256:e0fb4ca5df0ed983248c9c6c3242adc81d9cfddb8725902da53698554117abac", size = 923800 },
-]
-
-[[package]]
 name = "anyio"
 version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -341,24 +322,6 @@ wheels = [
 ]
 
 [[package]]
-name = "distro"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277 },
-]
-
-[[package]]
-name = "docstring-parser"
-version = "0.18.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484 },
-]
-
-[[package]]
 name = "elevenlabs"
 version = "2.53.0"
 source = { registry = "https://pypi.org/simple" }
@@ -452,96 +415,6 @@ wheels = [
 ]
 
 [[package]]
-name = "jiter"
-version = "0.15.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/66/b5/55f06bb281d92fb3cc86d14e1def2bd908bb77693183e7cb1f5a3c388b0c/jiter-0.15.0.tar.gz", hash = "sha256:4251acc80e2b7c9b7b8823456ea0fceeb0734dac2df7636d3c711b38476b5a76", size = 166640 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/13/daa722f5765c393576f466378f9dfd29d77c9bed939e0688f96afa3601ea/jiter-0.15.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0f862193b8696249d22ec433e85fd2ab0ad9596bc3e45e6c0bc55e8aeba97be2", size = 310899 },
-    { url = "https://files.pythonhosted.org/packages/7f/82/2d2551829b082f4b6d82b9f939b031fb808a10aab1ec0664f82e150bb9a2/jiter-0.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1303d4d68a9b051ea90502402063ecf3807da00ad2affa19ca1ae3b90b3c5f67", size = 314963 },
-    { url = "https://files.pythonhosted.org/packages/2a/0a/8b1a51466f7fe9f31dbe4bc7e0ca848674f9825e0f737b929b97e8c60aa7/jiter-0.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:392b8ab019e5502d08aff85c6272209c24bc2cbe706ea82a56368f524236614a", size = 341730 },
-    { url = "https://files.pythonhosted.org/packages/f6/2a/e71dea19822e2e404e83992a08c1d6b9b617bb944f28c9c2fbd85d02c91e/jiter-0.15.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:773b6eb282ce11ee19f05f6b2d4404fa308e5bbd353b0b80a0262caad6db2cd7", size = 366214 },
-    { url = "https://files.pythonhosted.org/packages/c4/59/97e1fa539d124a509a00ab7f669289d1c1d236ecabf12948a18f16c91082/jiter-0.15.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8d2c0c44d569ce0f2850f5c926f8caeb5f245fbc84475aeb36efccc2103e6dbd", size = 459527 },
-    { url = "https://files.pythonhosted.org/packages/d1/7a/4a68d331aef8cf2e2393c14a3aacb635c62aa86071b0229899fb5baaa907/jiter-0.15.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:032396229564bca02440396bd327710719f724f5e7b7e9f7a8eb3faa4a2c2281", size = 375451 },
-    { url = "https://files.pythonhosted.org/packages/7b/7e/1c445c2b6f0e30a274dc8082e0c3c7825411cce80d726bccd697c98cc8d3/jiter-0.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3d37768fce7f88dd2a8c6091f2325dea27d30d30d5c6e7a1c0f0af77723b708", size = 349428 },
-    { url = "https://files.pythonhosted.org/packages/00/94/e20d38984fc17a636371bffd2ae0f698124fdc8e75ef969cd2da6ba7cea7/jiter-0.15.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:2c9cb907439d20bd0c7d7565ca01ee52234203208433749bae5b516907526928", size = 355405 },
-    { url = "https://files.pythonhosted.org/packages/94/fa/4d09f814779d0ea80a28ed8e4c6662ec9a4a8ecef0ac52190ebac6262d14/jiter-0.15.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9100ddbec09741cc66feb0fc6773f8bdbd0e3c345689368f260082ff85dcc0cd", size = 393688 },
-    { url = "https://files.pythonhosted.org/packages/54/9d/8eb5d4fb8bf7e93a75964a5da71a75c67c864baf7fa3f98598187b3c7e57/jiter-0.15.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ae1b0d82ac2d987f9ea512b1c9adfcc71a28de3dea3a6039b54d76cffda9901e", size = 520853 },
-    { url = "https://files.pythonhosted.org/packages/e7/2c/5e07874e59e623a943a0acf1552a80d05b70f31b402287a8fc6d7ec634c7/jiter-0.15.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8020c99ec13a7db2b6f96cbe82ef4721c88b426a4892f27478044af0284615ef", size = 551016 },
-    { url = "https://files.pythonhosted.org/packages/22/ed/d2d34422143474cadc15b60d482b1c35683dbc5c63c24346ddd0df09bcaf/jiter-0.15.0-cp311-cp311-win32.whl", hash = "sha256:42bfb257930800cf43e7c62c832402c704ab60797c992faf88d20e903eac8f32", size = 209518 },
-    { url = "https://files.pythonhosted.org/packages/1d/7d/52778b930e5cc3e52a37d950b1c10494244308b4329b25a0ff0d88303a81/jiter-0.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:860a74063284a2ae9bfedd694f299cc2c68e2696c5f3d440cc9d18bb81b9dd04", size = 200565 },
-    { url = "https://files.pythonhosted.org/packages/3b/4f/d9b4067feb69b3fa6eb0488e1b59e2ad5b463fe39f59e527eab2aca00bb0/jiter-0.15.0-cp311-cp311-win_arm64.whl", hash = "sha256:37a10c377ce3a4a85f4a67f28b7afe093154cde77eaf248a72e856aa08b4d865", size = 195488 },
-    { url = "https://files.pythonhosted.org/packages/44/53/4f6bddbcde3c71e56d0aa1337ec95950f3d27dd4153e25aadf0feac71751/jiter-0.15.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0e90a1c315a0226ec822d973817967f9223b7701546c8c2a7913e7ab0926294d", size = 308793 },
-    { url = "https://files.pythonhosted.org/packages/01/84/c01099b59a285a1ebba64ae93f62bfa036675340fd1b0045ae65890a0442/jiter-0.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8c9004af7c8d67cce7f1aae1026fb55607f4aa600710d08ede3a3ce4aeefe7e0", size = 309570 },
-    { url = "https://files.pythonhosted.org/packages/58/64/8fb7f9d45bb98190355454cd04dad8d8f27223d6bd52f83af07f637168a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c210f8b35dc6f30aafd4b4365ca89b9d1189f21ab49b8e68fa6322a847aef138", size = 336783 },
-    { url = "https://files.pythonhosted.org/packages/c3/b6/f5739011d009b3a30f6a53c5240979030ba29ae46a8c67e3a15759f7c37d/jiter-0.15.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f30bae8bc1c2d613e28e5af3e8cceb09b742f1c8a8a5f839fb67afaffc03b61", size = 363555 },
-    { url = "https://files.pythonhosted.org/packages/e5/12/98a9d9f766665e8a3b6252454e17cb0c464606a28cf2fa09399b003345fa/jiter-0.15.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c60e71b6d10cfc284c9bf36bd885e8d44c46f688ce50aa91b5edd90181dea687", size = 452255 },
-    { url = "https://files.pythonhosted.org/packages/e8/d5/60f972840f79c5e7544fce567c56f1e4e50468f996baba3e78d823dd62a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ab068bce62a45aa3e7367eceaffb5dde60b7eb853be8dece45132e3d0ff4879", size = 373559 },
-    { url = "https://files.pythonhosted.org/packages/ee/cf/d46ef1234ba335aabc2f013210db8e0821a22f5e644a2e9449df199ecc23/jiter-0.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa248c9eb220197d363f688818dac2fd4b2f0cd7d843ca7105d652034823427d", size = 346055 },
-    { url = "https://files.pythonhosted.org/packages/f0/63/4d2749d8d54d230bad9b3a6b0d00cc28c6ff6b2fdffc26a8ccf76cc5a974/jiter-0.15.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2a77aadd57cac1682e4401a72724d2796d89a4ba129b1a5812aa94ee480826eb", size = 351406 },
-    { url = "https://files.pythonhosted.org/packages/d9/b9/9965b990035d8773328e0a8c8b457a87bf2b19f6c4126d9d99296be5d16a/jiter-0.15.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2ae901f3a55bfafdde31d289590fa25e3245735a2b1e8c7cc15871710a002871", size = 389357 },
-    { url = "https://files.pythonhosted.org/packages/2d/55/9ddf903deda1413e87fed792f416b7123daee5b8efbad6a202a7421c36a5/jiter-0.15.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f0b271b462769543716f92d3a4f90527df6ef5ed05ee95ec4137f513e21e1b77", size = 517263 },
-    { url = "https://files.pythonhosted.org/packages/e8/76/a0c40ad064d3a20a4fde231e35d56e9a01ce82164278180e82d5daf85469/jiter-0.15.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2fb6a5d26af81fc0f00f9360a891e05cf755e149bba391c4d563adc54812973d", size = 548646 },
-    { url = "https://files.pythonhosted.org/packages/23/4f/eca9b954942916ba2f453891b8593ab444cd872396fe66a3936616f236f3/jiter-0.15.0-cp312-cp312-win32.whl", hash = "sha256:c2f6bb8b5216ab9e7873bc08b5d7bef2b8abbb578a3069bf1cd14a45d71d771d", size = 206427 },
-    { url = "https://files.pythonhosted.org/packages/95/bf/8ead82a87495149542748e828d153fd232a512a22c83b02c4815c1a9c7d8/jiter-0.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:40b2c7e92c44a84d748d21706c68dc6ff8161d80b59c99d774721a0d2317d7c7", size = 197300 },
-    { url = "https://files.pythonhosted.org/packages/f4/e4/9b8a78fb2d894471bc344e37f1949bdd784bd914d031dba0ba3a40c71dd7/jiter-0.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:cc0bc345cf2df9d1c00ac443f50d543c1ccfa8b0422cb85b1ab70d681c0b255b", size = 192702 },
-    { url = "https://files.pythonhosted.org/packages/e5/f4/f708c900ecee41b2025ef8413d5351e5649eb2125c506f6720cc69b06f5c/jiter-0.15.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1c11465f97e2abf45a014b83b730222f8f1c5335e802c7055a67d50de6f1f4e3", size = 307829 },
-    { url = "https://files.pythonhosted.org/packages/86/59/db537c0949e83668c38481d426b9f2fd5ab758c4ee53a811dd0a510626a0/jiter-0.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d1e7b1776f0797956c509e123d0952d10d293a9492dea9f288ab9570ec01d1a5", size = 308445 },
-    { url = "https://files.pythonhosted.org/packages/37/38/ea0e13b18c30ef951da0d47d39e7fa9edb82a93a62990ffbd7cea9b622d4/jiter-0.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:351a341c2105aa430b7047e30f1bf7975f6313b00165d3fc07be2edaf741f279", size = 336181 },
-    { url = "https://files.pythonhosted.org/packages/58/fc/2303901b16c4ba05865588990a420c0b4156270b44379c20931544a1d962/jiter-0.15.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4ab395feec8d249ec4044e228e98a7033f043426a265df439dc3698823f0a4e4", size = 362985 },
-    { url = "https://files.pythonhosted.org/packages/5b/6f/11bace093c52e7d4d26c8e606ccd7ae8c972189622469ec0d9e28161e28b/jiter-0.15.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a2a438005b6f22d0273413484d6094d7c2c5d10ec1b3a3bf128e0d1d3ba53258", size = 453292 },
-    { url = "https://files.pythonhosted.org/packages/22/db/987f2f086ca4d7a6582eb4ccd513f9b26b42d9e4243a087609a3137a8fc7/jiter-0.15.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f18f85e4218d1b40f000f42a92239a7a61a902cd42c65e6c360dbd17dcb20894", size = 373501 },
-    { url = "https://files.pythonhosted.org/packages/8f/7c/89fbcabb2739b7a5b8dc959a1b6c5761f6484f5fed3486854b3c789bb1de/jiter-0.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1aa62e277fc1cbd80e6deacae6f4d983b41b3d7728e0645c5d741a6149bba45", size = 344683 },
-    { url = "https://files.pythonhosted.org/packages/30/6f/6cca7692e7dddfec6d8d76c54dc97f2af2a41df4ac0674b999df1f09a5f3/jiter-0.15.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:6550fa135c7deb8ead6af49ed7ff648532ea8334a1447fe34a36315ef79c5c29", size = 350892 },
-    { url = "https://files.pythonhosted.org/packages/39/14/0338d6190cb8e6d22e677ab1d4eabd4117f67cca70c54cd04b82ff64e068/jiter-0.15.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:066f8f33f18b2419cd8213b2436fa7fbc9c499f315971cfa3ce1f9820c001b1b", size = 388723 },
-    { url = "https://files.pythonhosted.org/packages/90/31/cc19f4a1bdb6afb09ce6a2f2615aa8d44d994eba0d8e6105ed1af920e736/jiter-0.15.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:75e8a04e91432dde9f1838373cf93d23726c79d3e908d319acf0e796f85592e7", size = 516648 },
-    { url = "https://files.pythonhosted.org/packages/49/9f/833c541512cd091b63c10c0381973dfe11bc7a503a818c16384417e0c81e/jiter-0.15.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a97261f1fccb8e50ecd2890a96e46efdc3f57c80a197324c6777827231eca712", size = 547382 },
-    { url = "https://files.pythonhosted.org/packages/d2/11/e7b70e91f90bc4477e8eee9e8a5f7cf3cb41b4525d6394dc98a714eb8f7f/jiter-0.15.0-cp313-cp313-win32.whl", hash = "sha256:c77496cb10bd7549690fbbab3e5ec05857b83e49276f4a9423a766ddd2afcd4c", size = 205845 },
-    { url = "https://files.pythonhosted.org/packages/4b/23/5c20d9ad6f02c493e4023e5d2d09e1c1f15fe2753c9102c544aff068a88e/jiter-0.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b15741f501469009ae0ae90b7147958a664a7dede40aa7ff174a8a4645f546d0", size = 196842 },
-    { url = "https://files.pythonhosted.org/packages/6b/11/1eb400ef248e8c925fd883fbe325daf5e42cd1b0d308539dd332bd4f7ffc/jiter-0.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:5d6a60072b44c3c2b797a7ddcbcbbf2b34ea3cfd4721580fbfd2a09d9d9b84ba", size = 192212 },
-    { url = "https://files.pythonhosted.org/packages/8a/60/2fd8d7c79da8acf9b7b277c7616847773779356b92acfc9bb158452174da/jiter-0.15.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ef1fd24d9413f6209e00d3d5a453e67acfe004a25cc6c8e8484faed4311ab9e8", size = 315065 },
-    { url = "https://files.pythonhosted.org/packages/46/f4/008fb7d65e8ac2abf00811651a661e025c4ba80bbc6f378450384ddd3aed/jiter-0.15.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:144f8e72cb53dab146347b91cceac01f5481237f2b93b4a339a1ee8f8878b67c", size = 339444 },
-    { url = "https://files.pythonhosted.org/packages/00/55/90b0c7b9c6896c0f2a591dd36d36b71d22e09674bfef178fa03ba3f81499/jiter-0.15.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:553fcac2ef2cb990877f9fc0833b8b629a3e6a5670b6b5fd58219b41a653ddc4", size = 347779 },
-    { url = "https://files.pythonhosted.org/packages/51/6b/69666cec5000fd57734c118437394516c749ae8dbeea9fb66d6fef9c4775/jiter-0.15.0-cp313-cp313t-win_amd64.whl", hash = "sha256:774f93f65031856bf14ad9f59bdcab8b8cad501e5ceabd51ba3525f76937a25b", size = 200395 },
-    { url = "https://files.pythonhosted.org/packages/39/04/a6aa62cd27e8149b0d28df5561f10f6cceaf7935a9ccf3f1c5a05f9a0cd8/jiter-0.15.0-cp313-cp313t-win_arm64.whl", hash = "sha256:f1e1754960f38ec40613a07e5e372df67acb3b890fb383b6fb3de3e49ddbf3c7", size = 190516 },
-    { url = "https://files.pythonhosted.org/packages/eb/d2/079f350ebf7859d081de30aa890f9e3be68516f754f3ba32366ffff4dcee/jiter-0.15.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:ac0d9ddea4350974be7a221fc25895f251a8fee748c889bdced2141c0fec1a49", size = 308884 },
-    { url = "https://files.pythonhosted.org/packages/04/4e/a2c30a7f69b48c03b20935d647479106fe932f6e63f75faf53937197e05d/jiter-0.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01a8222cf05ab1128e239421156c207949808acaaea2bdfd33130ae666786e86", size = 310028 },
-    { url = "https://files.pythonhosted.org/packages/40/90/2e7cdfd3cf8ca967be38c48f5cf474d79f089efaf559a40f15984a77ae69/jiter-0.15.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:182226cbc930c9fab81bc2e41a4da672f89539906dadb05e75670ac07b94f71f", size = 337485 },
-    { url = "https://files.pythonhosted.org/packages/9b/11/15a1aa28b120b8ee5b4f1fb894c125046225f09847738bd64233d3b84883/jiter-0.15.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:71683c38c825452999b5717fcae07ea708e8c93003e808be4319c1b02e3d176e", size = 364223 },
-    { url = "https://files.pythonhosted.org/packages/b7/25/f442e8af5f3d0dcf47b39e83a0efd9ee45ea946aa6d04625dc3181eae3b6/jiter-0.15.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30f2218e6a9e5c18bc10fe6d41ac189c442c88eacf11bad9f28ef95a9bef00e6", size = 456387 },
-    { url = "https://files.pythonhosted.org/packages/da/f4/37f2d2c9f64f49af7da652ed7532bb5a2372e588e6927c3fdd76f911db65/jiter-0.15.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5157de9f76eb4bc5ea74a1219366a25f945ad305641d74e04f59c54087091aa9", size = 374461 },
-    { url = "https://files.pythonhosted.org/packages/60/28/edcfbbbf0cb15436f36664a8908a0df47ab9006298d4cd937dc08ea932d6/jiter-0.15.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90c5db5527c221249a876160663ab891ace358c17f7b9c93ec1478b7f0550e5c", size = 345924 },
-    { url = "https://files.pythonhosted.org/packages/47/13/89fba6398dab7f202b7278c4b4aac122399d2c0183971c4a57a3b7088df5/jiter-0.15.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:3e4540b8e74e4268811ac05db226a6a128ff572e7e0ce3f1163b693cadb184cd", size = 352283 },
-    { url = "https://files.pythonhosted.org/packages/1b/da/0f6af8cef2c565a1ab44d970f268c43ccaa72707386ea6388e6fe2b6cd26/jiter-0.15.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:62ebd14e47e9aed9df4472afcb2663668ce4d74891cd54f86bf6e44029d6dc89", size = 389985 },
-    { url = "https://files.pythonhosted.org/packages/a1/ec/b9cb7d6d29e24ee14910266157d2a279d7a8f60ee0df7fa840882976ba64/jiter-0.15.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0be6f5ad41a809f303f416d17cec92a7a725902fb9b4f3de3d19362ac0ef8554", size = 517695 },
-    { url = "https://files.pythonhosted.org/packages/64/5e/6d1bda880723aae0ad86b4b763f044362448efe31e3e819635d41cb03451/jiter-0.15.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:813dfbb17d65328bf86e5f0905dd277ba2265d3ca20556e86c0c7035b7182e5a", size = 548868 },
-    { url = "https://files.pythonhosted.org/packages/0c/72/7de501cf38dcacaf35098796f3a50e0f2e338baba18a58946c618544b809/jiter-0.15.0-cp314-cp314-win32.whl", hash = "sha256:50e51156192722a9c58db112837d3f8ef96fb3c5ecc14e95f409134b08b158ec", size = 206380 },
-    { url = "https://files.pythonhosted.org/packages/1e/a9/e19addf4b0c1bdce52c6da12351e6bc42c340c45e7c09e2158e46d293ccc/jiter-0.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:30ce1a5d16b5641dc935d50ef775af6a0871e3d14ab05d6fc54dff371b78e558", size = 197687 },
-    { url = "https://files.pythonhosted.org/packages/f2/c9/776b1db01db25fc6c1d58d1979a37b0a9fe787e5f5b1d062d2eaacb77923/jiter-0.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:510c8b3c17a0ed9ac69850c0438dada3c9b82d9c4d589fcb62002a5a9cf3a866", size = 192571 },
-    { url = "https://files.pythonhosted.org/packages/a0/f6/45bb4670bacf300fd2c7abadbfb3af376e5f1b6ae75fd9bc069891d15870/jiter-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7553333dd0930c104a5a0db8df72bf7219fe663d731383b576bb6ed6351c984d", size = 317151 },
-    { url = "https://files.pythonhosted.org/packages/d7/68/ed635ad5acd7b73e454283083bbb7c8205ad10e88b0d9d7d793b09fe8226/jiter-0.15.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2143ab06181d2b029eedcb6af3cebe95f11bbac62441781860f98ee9330a6a6", size = 341243 },
-    { url = "https://files.pythonhosted.org/packages/5d/db/3ff4176b817b8ea33879e71e13d8bc2b0d481a7ed3fe9e080f333d415c16/jiter-0.15.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6eac374c5c975709b69c10f09afd199df74150172156ad10c8d4fd785b7da995", size = 363629 },
-    { url = "https://files.pythonhosted.org/packages/ab/24/5f8270e0ba9c883582f96f722f8a0b58015c7ce1f8c6d4571cf394e99b6b/jiter-0.15.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b3b3b775e33d3bfaec9899edc526ae97b0da0bf9d071a46124ba419149a414f8", size = 456198 },
-    { url = "https://files.pythonhosted.org/packages/45/5b/76fc02b0b5c54c3d18c60653156e2f76fde1816f9b4722db68d6ee2c897e/jiter-0.15.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3071db3346334beae1360b46da4606da57bf3528c167b3c38533afaf9f2c5", size = 373710 },
-    { url = "https://files.pythonhosted.org/packages/c4/52/4310821b0ea9277994d3e1f49fc6a4b34e4800caebacb2c0af81da59a454/jiter-0.15.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6694a173ecabc12eb60efbc0b474464ead1951ff65cd8b1e72100715c64512b", size = 349901 },
-    { url = "https://files.pythonhosted.org/packages/93/fe/67648c35b3594fba8854ac64cc8a826d8bcd18324bbdb53d77697c60b6ef/jiter-0.15.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:a254e10b593624d230c365b6d616b22ca0ad65e63a16e6631c2b3466022e6ba8", size = 352438 },
-    { url = "https://files.pythonhosted.org/packages/cb/28/0a1879d07ad6b3e025a2750027363452ced93c2d16d1c9d4b153ffd51c91/jiter-0.15.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d8d2955167274e15d79a7a020afdd9b39c990eb80b2d89fca695d92dcfdd38ec", size = 388152 },
-    { url = "https://files.pythonhosted.org/packages/c1/78/46c6f6b56ba85c90021f4afd72ed42f691f8f84daacb5fe27277070e3858/jiter-0.15.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:acf4ee4d1fc55917239fe72972fb292dd773055d05eb040d36f4326e02cc2c0e", size = 517707 },
-    { url = "https://files.pythonhosted.org/packages/ca/cb/720662d4c88fcad606e826fef5424365527ba43ce4868a479aed8f8c507e/jiter-0.15.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:e7196e56f1cd69af1dbb07dff02dcfb260a50b45a82d409d92a06fedb32473b5", size = 548241 },
-    { url = "https://files.pythonhosted.org/packages/60/e3/935b8034fd143f21125c87d51404a9e0e1449186a494405721ff5d1d695e/jiter-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:7f6163c0f10b055245f814dcc59f4818da60dfe72f3e72ab89fc24b6bd5e9c52", size = 207950 },
-    { url = "https://files.pythonhosted.org/packages/93/59/984fd9ece895953dad3e0880a650e766f5a2da2c5514f0eafdaaabbeb5f9/jiter-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:980c256edb05b78a111b99c4de3b1d32e31634b867fd1fc2cf726e7b7bba9854", size = 200055 },
-    { url = "https://files.pythonhosted.org/packages/0e/a4/cf8d779feb133a27a2e3bc833bccb9e13aa332cdf820497ebf72c10ce8c3/jiter-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:66b1880df2d01e206e8339769d1c7c1753bcb653efd6289e203f6f24ebada0c0", size = 191244 },
-    { url = "https://files.pythonhosted.org/packages/65/43/1fc62172aa98b50a7de9a25554060db510f85c89cfbed0dfe13e1907a139/jiter-0.15.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:411fa4dfa5a7ae3d11491027ffb9beadec3996010a986862db70d91abba1c750", size = 305585 },
-    { url = "https://files.pythonhosted.org/packages/e8/c4/dd58fcd9e2df83666e5c1c1347bef58ce919cd8efc3ffa38aeea62ce493b/jiter-0.15.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:2b0074e2f56eb2dacca1689760fd2852a068f85a0547a157b82cb4cafeb6768b", size = 306936 },
-    { url = "https://files.pythonhosted.org/packages/39/86/b695e16f1180c07f43ea98e73ecd21cf63fa2e1b0c1103739013784d11ae/jiter-0.15.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:913d02d29c9606643418d9ccfc3b72492ab25a6bf7889934e09a3490f8d3438b", size = 342453 },
-    { url = "https://files.pythonhosted.org/packages/34/56/55d76614af37fe3f22a3347d1e410d2a15da581997cb2da499a625000bb5/jiter-0.15.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b15d3ec9b0449c40e85319bdb4caa8b77ab526e74f5532ed94bec15e2f66822c", size = 345606 },
-    { url = "https://files.pythonhosted.org/packages/73/38/505941b2b092fd5bbbd60a52a880db1173f1690ae6751bed3af1c9ddcb4e/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:631f13a3d04e97d4e083993b10f4b99530e3a10d953e2eb5e196b7dc7f812ce0", size = 303769 },
-    { url = "https://files.pythonhosted.org/packages/e7/95/a06692b29e77473f286e1ec1f426d3ca44d7b5843be8ad21d7a5f3fcdcc0/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:b6c0ffae686c39bf3737be60793783267628783ea42545632c10b291105aee45", size = 305128 },
-    { url = "https://files.pythonhosted.org/packages/23/85/7270d7ad41d6061a25b950c6bf91d638bd9aacb113200a8c8d57a055fd67/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d54fb5b31dea401a41af3f8a7d2512e9b6a6a005491e6166c7e4ffab9639a9c", size = 340459 },
-    { url = "https://files.pythonhosted.org/packages/c8/8d/302cb2057b7513327b4d575cff6b1d066ee6431a5357fc3f8867cd684406/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d5d6090cdc1b7c9e780dfb04949a990adb1e301a2fc0bbcee7de4638d33f9a", size = 344469 },
-]
-
-[[package]]
 name = "jsonpatch"
 version = "1.33"
 source = { registry = "https://pypi.org/simple" }
@@ -601,20 +474,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/56/7c/651d0dc4913a7a892156c03dd343b99cfe19ee729e6911ab1f4fe7567b8b/langchain-1.3.9.tar.gz", hash = "sha256:9b14ef0db9ef314299ded858b22ca2a40b8f1b05c8c9cb6b82d53a53075fef00", size = 631514 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/55/3481619d21b9bdfbfda8680fba5cfc6cfe926789b8eaaad95353078cfa20/langchain-1.3.9-py3-none-any.whl", hash = "sha256:4af49ad1095799e4408b489fb79d4b8b49292453618b202d8a697fca59bb6871", size = 132873 },
-]
-
-[[package]]
-name = "langchain-anthropic"
-version = "1.4.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anthropic" },
-    { name = "langchain-core" },
-    { name = "pydantic" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/f5/cd397b94aeed5fa0e8ab9595b9fb578ac99f424d42220defe6626e6a1a7b/langchain_anthropic-1.4.6.tar.gz", hash = "sha256:78942d4458d883b7d362438a095ed501ed84f44d402622404482481fc973b9da", size = 706540 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/af/927dbbc5a1f5fea1a69adc2883f034cbd1430004e36f4eacd302d500393a/langchain_anthropic-1.4.6-py3-none-any.whl", hash = "sha256:dbd412a956b6b8b0716d9d8460ef71f834a6731cdbfc59e6160482a4a9fb5200", size = 51797 },
 ]
 
 [[package]]
@@ -1556,12 +1415,10 @@ name = "sentryinsight"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "anthropic" },
     { name = "elevenlabs" },
     { name = "feedparser" },
     { name = "httpx" },
     { name = "langchain" },
-    { name = "langchain-anthropic" },
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "mcp-python" },
@@ -1581,12 +1438,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic" },
     { name = "elevenlabs" },
     { name = "feedparser" },
     { name = "httpx" },
     { name = "langchain", specifier = ">=0.1.0" },
-    { name = "langchain-anthropic" },
     { name = "langchain-core" },
     { name = "langgraph", specifier = ">=0.0.20" },
     { name = "mcp-python", specifier = ">=0.1.0" },
@@ -1609,15 +1464,6 @@ name = "sgmllib3k"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9e/bd/3704a8c3e0942d711c1299ebf7b9091930adae6675d7c8f476a7ce48653c/sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9", size = 5750 }
-
-[[package]]
-name = "sniffio"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
-]
 
 [[package]]
 name = "sse-starlette"


### PR DESCRIPTION
## Summary
- Add an OpenCode session client for report generation.
- Require explicit provider/model config through `SENTRYINSIGHT_MODEL`.
- Remove direct Anthropic runtime packages and legacy model fallback paths.

## Motivation
Report generation should route model calls through one provider-switchable interface.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -B -m pytest -q tests/test_model_config.py tests/test_analyze_guards.py tests/test_opencode_client.py -p no:cacheprovider`
- `PYTHONPYCACHEPREFIX=/private/tmp/codex-pycache python3 -m py_compile src/core/opencode_client.py src/core/analyze.py`