### PR TITLE
Redact upstream model errors

### DIFF
--- a/src/core/analyze.py
+++ b/src/core/analyze.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import List, Dict, Any
 from datetime import datetime
 

--- a/src/core/opencode_client.py
+++ b/src/core/opencode_client.py
@@ -108,9 +108,7 @@ class OpenCodeClient:
     def _raise_for_status(self, response: httpx.Response, action: str) -> None:
         if response.is_success:
             return
-        raise OpenCodeError(
-            f"Failed to {action}: HTTP {response.status_code} {response.text}"
-        )
+        raise OpenCodeError(f"Failed to {action}: HTTP {response.status_code}")
 
     def _extract_text(self, payload: dict[str, Any]) -> str:
         parts = payload.get("parts", [])

--- a/tests/test_opencode_client.py
+++ b/tests/test_opencode_client.py
@@ -49,6 +49,31 @@ class OpenCodeClientTests(unittest.TestCase):
             ["/session", "/session/session-1/message"],
         )
 
+    def test_generate_redacts_failed_response_body(self):
+        def handler(request):
+            if request.url.path == "/session":
+                return httpx.Response(500, text="secret prompt fragment")
+            return httpx.Response(404)
+
+        client = OpenCodeClient(
+            base_url="http://opencode.test",
+            transport=httpx.MockTransport(handler),
+        )
+
+        with self.assertRaisesRegex(
+            Exception,
+            r"Failed to create OpenCode session: HTTP 500",
+        ) as raised:
+            asyncio.run(
+                client.generate(
+                    system_prompt="system",
+                    user_prompt="user",
+                    model=parse_model_selection("openai/gpt-5"),
+                )
+            )
+
+        self.assertNotIn("secret prompt fragment", str(raised.exception))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Remove upstream response bodies from model client exceptions.
- Restore the template path import caught by local validation.
- Add a regression test for failed OpenCode responses.

## Validation
- `UV_CACHE_DIR=/private/tmp/sentryinsight-uv-cache RUFF_CACHE_DIR=/private/tmp/sentryinsight-ruff-cache bash scripts/local_validation.sh`