### PR TITLE
Harden report error validation

### DIFF
--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -43,8 +43,9 @@ def validate_report_content(markdown: str) -> List[ReportValidationIssue]:
             )
         ]
 
+    normalized_content = content.casefold()
     for marker in ERROR_MARKERS:
-        if marker in content:
+        if marker.casefold() in normalized_content:
             issues.append(
                 ReportValidationIssue(
                     code="error_marker",

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -38,6 +38,13 @@ class ReportValidationTests(unittest.TestCase):
 
         self.assertTrue(any(issue.code == "error_marker" for issue in issues))
 
+    def test_api_error_marker_matching_is_case_insensitive(self):
+        issues = validate_report_content(
+            "# exploitation report\n\nupstream response returned error code: 404"
+        )
+
+        self.assertTrue(any(issue.code == "error_marker" for issue in issues))
+
     def test_missing_required_section_fails(self):
         issues = validate_report_content("# Exploitation Report\n\nSummary only")
 


### PR DESCRIPTION
## Summary
- match blocked report error markers case-insensitively
- add coverage for lowercase API error text

## Validation
- bash scripts/local_validation.sh