### PR TITLE
Use free OpenRouter model defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 # Copy this file to .env and fill in your API keys
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
-SENTRYINSIGHT_ANTHROPIC_MODEL=claude-sonnet-4-6
+SENTRYINSIGHT_MODEL=openrouter/nvidia/nemotron-3-ultra-550b-a55b:free

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Automated cybersecurity threat intelligence that monitors RSS feeds and generate
    Model IDs use `provider/model` format. Override the model for one
    environment with:
    ```bash
-   export SENTRYINSIGHT_MODEL=anthropic/claude-sonnet-4-6
+   export SENTRYINSIGHT_MODEL=openrouter/nvidia/nemotron-3-ultra-550b-a55b:free
    ```
    If OpenCode is not listening on `http://127.0.0.1:4096`, set:
    ```bash

--- a/config/config.json
+++ b/config/config.json
@@ -2,7 +2,7 @@
     "feed_url": "https://ricomanifesto.github.io/SentryDigest/feed.xml",
     "output_path": "index.md",
     "analysis": {
-        "model": "anthropic/claude-sonnet-4-6",
+        "model": "openrouter/nvidia/nemotron-3-ultra-550b-a55b:free",
         "max_tokens": 4000,
         "temperature": 1,
         "analysis_focus": [

--- a/src/core/model_config.py
+++ b/src/core/model_config.py
@@ -4,12 +4,10 @@ import os
 import re
 from typing import Any, Dict
 
-DEFAULT_MODEL = "anthropic/claude-sonnet-4-6"
+DEFAULT_MODEL = "openrouter/nvidia/nemotron-3-ultra-550b-a55b:free"
 MODEL_ENV_VAR = "SENTRYINSIGHT_MODEL"
 
-_MODEL_ID_PATTERN = re.compile(
-    r"^[a-z][a-z0-9_-]*/[a-z][a-z0-9._-]*(?:-[a-z0-9._-]+)*$"
-)
+_MODEL_ID_PATTERN = re.compile(r"^[a-z][a-z0-9_-]*/[a-z0-9._:/-]+$")
 _KNOWN_UNAVAILABLE_MODELS = {
     "claude-sonnet-4-20250514",
 }

--- a/tests/test_analyze_guards.py
+++ b/tests/test_analyze_guards.py
@@ -53,8 +53,10 @@ class AnalyzeGuardTests(unittest.TestCase):
 
             async def generate(self, **kwargs):
                 self.kwargs = kwargs
-                assert kwargs["model"].provider_id == "anthropic"
-                assert kwargs["model"].model_id == "claude-sonnet-4-6"
+                assert kwargs["model"].provider_id == "openrouter"
+                assert (
+                    kwargs["model"].model_id == "nvidia/nemotron-3-ultra-550b-a55b:free"
+                )
                 return "# Exploitation Report\n\nGenerated through OpenCode."
 
         analyze.OpenCodeClient = FakeOpenCodeClient
@@ -63,7 +65,11 @@ class AnalyzeGuardTests(unittest.TestCase):
             result = asyncio.run(
                 analyze.analyze_exploitation(
                     articles=[],
-                    config={"analysis": {"model": "anthropic/claude-sonnet-4-6"}},
+                    config={
+                        "analysis": {
+                            "model": "openrouter/nvidia/nemotron-3-ultra-550b-a55b:free"
+                        }
+                    },
                 )
             )
 

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -12,17 +12,34 @@ from src.core.opencode_client import parse_model_selection
 
 
 class ModelConfigTests(unittest.TestCase):
+    def test_default_model_uses_free_openrouter_report_model(self):
+        self.assertEqual(
+            DEFAULT_MODEL,
+            "openrouter/nvidia/nemotron-3-ultra-550b-a55b:free",
+        )
+
     def test_resolves_model_from_config(self):
-        config = {"analysis": {"model": "anthropic/claude-sonnet-4-6"}}
+        config = {
+            "analysis": {"model": "openrouter/nvidia/nemotron-3-ultra-550b-a55b:free"}
+        }
 
         with patch.dict(os.environ, {}, clear=True):
-            self.assertEqual(resolve_model(config), "anthropic/claude-sonnet-4-6")
+            self.assertEqual(
+                resolve_model(config),
+                "openrouter/nvidia/nemotron-3-ultra-550b-a55b:free",
+            )
 
     def test_env_override_wins(self):
-        config = {"analysis": {"model": "anthropic/claude-haiku-4-5"}}
+        config = {
+            "analysis": {"model": "openrouter/nvidia/nemotron-3-ultra-550b-a55b:free"}
+        }
 
-        with patch.dict(os.environ, {MODEL_ENV_VAR: "openai/gpt-5"}):
-            self.assertEqual(resolve_model(config), "openai/gpt-5")
+        with patch.dict(
+            os.environ, {MODEL_ENV_VAR: "openrouter/nex-agi/nex-n2-pro:free"}
+        ):
+            self.assertEqual(
+                resolve_model(config), "openrouter/nex-agi/nex-n2-pro:free"
+            )
 
     def test_empty_config_uses_default(self):
         with patch.dict(os.environ, {}, clear=True):
@@ -33,17 +50,22 @@ class ModelConfigTests(unittest.TestCase):
             validate_model("anthropic/claude-sonnet-4-20250514")
 
     def test_accepts_provider_model(self):
-        validate_model("openai/gpt-5")
+        validate_model("openrouter/nex-agi/nex-n2-pro:free")
+
+    def test_accepts_openrouter_nested_model_id(self):
+        validate_model("openrouter/nvidia/nemotron-3-ultra-550b-a55b:free")
 
     def test_rejects_bare_provider_model(self):
         with self.assertRaises(ValueError):
             validate_model("claude-sonnet-4-6")
 
     def test_parses_explicit_provider_model(self):
-        model = parse_model_selection("anthropic/claude-sonnet-4-6")
+        model = parse_model_selection(
+            "openrouter/nvidia/nemotron-3-ultra-550b-a55b:free"
+        )
 
-        self.assertEqual(model.provider_id, "anthropic")
-        self.assertEqual(model.model_id, "claude-sonnet-4-6")
+        self.assertEqual(model.provider_id, "openrouter")
+        self.assertEqual(model.model_id, "nvidia/nemotron-3-ultra-550b-a55b:free")
 
 
 if __name__ == "__main__":

--- a/tests/test_opencode_client.py
+++ b/tests/test_opencode_client.py
@@ -19,7 +19,7 @@ class OpenCodeClientTests(unittest.TestCase):
                 payload = json.loads(request.content.decode())
                 self.assertEqual(
                     payload["model"],
-                    {"providerID": "openai", "modelID": "gpt-5"},
+                    {"providerID": "openrouter", "modelID": "nex-agi/nex-n2-pro:free"},
                 )
                 return httpx.Response(
                     200,
@@ -39,7 +39,7 @@ class OpenCodeClientTests(unittest.TestCase):
             client.generate(
                 system_prompt="system",
                 user_prompt="user",
-                model=parse_model_selection("openai/gpt-5"),
+                model=parse_model_selection("openrouter/nex-agi/nex-n2-pro:free"),
             )
         )
 
@@ -68,7 +68,7 @@ class OpenCodeClientTests(unittest.TestCase):
                 client.generate(
                     system_prompt="system",
                     user_prompt="user",
-                    model=parse_model_selection("openai/gpt-5"),
+                    model=parse_model_selection("openrouter/nex-agi/nex-n2-pro:free"),
                 )
             )
 


### PR DESCRIPTION
## Summary
- Set the default report model to `openrouter/nvidia/nemotron-3-ultra-550b-a55b:free`.
- Update config, environment examples, and model validation for nested OpenRouter model IDs.
- Keep explicit model overrides supported through `SENTRYINSIGHT_MODEL`.

## Validation
- `PATH=/Users/michaelrico/.local/bin:$PATH bash scripts/local_validation.sh`