### PR TITLE
Skip unavailable report model server

### DIFF
--- a/src/core/analyze.py
+++ b/src/core/analyze.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import tiktoken
 
 from .model_config import resolve_model, validate_model
-from .opencode_client import OpenCodeClient, parse_model_selection
+from .opencode_client import OpenCodeClient, OpenCodeUnavailable, parse_model_selection
 
 # Configure logging
 logging.basicConfig(
@@ -214,6 +214,16 @@ Generate a well-formatted exploitation report following the structure above. Be 
             "date": datetime.now().strftime("%Y-%m-%d"),
             "analyzed_article_count": len(articles),
             "cves_identified": list(all_cves),
+        }
+    except OpenCodeUnavailable as e:
+        logger.warning(f"Skipping exploitation analysis: {e}")
+        return {
+            "exploitation_report": "",
+            "date": datetime.now().strftime("%Y-%m-%d"),
+            "analyzed_article_count": len(articles),
+            "cves_identified": list(all_cves),
+            "skipped": True,
+            "skip_reason": str(e),
         }
     except Exception as e:
         logger.error(f"Error during exploitation analysis: {e}")

--- a/src/core/opencode_client.py
+++ b/src/core/opencode_client.py
@@ -18,6 +18,10 @@ class OpenCodeError(RuntimeError):
     """Raised when OpenCode cannot return usable model output."""
 
 
+class OpenCodeUnavailable(OpenCodeError):
+    """Raised when the configured OpenCode server cannot be reached."""
+
+
 @dataclass(frozen=True)
 class ModelSelection:
     """Provider and model IDs accepted by the OpenCode message API."""
@@ -72,31 +76,34 @@ class OpenCodeClient:
     ) -> str:
         """Generate text through an OpenCode server session."""
         auth = self._auth()
-        async with httpx.AsyncClient(
-            base_url=self.base_url,
-            timeout=self.timeout,
-            transport=self.transport,
-            auth=auth,
-        ) as client:
-            session_response = await client.post("/session", json={"title": title})
-            self._raise_for_status(session_response, "create OpenCode session")
-            session_id = session_response.json().get("id")
-            if not session_id:
-                raise OpenCodeError("OpenCode did not return a session id")
+        try:
+            async with httpx.AsyncClient(
+                base_url=self.base_url,
+                timeout=self.timeout,
+                transport=self.transport,
+                auth=auth,
+            ) as client:
+                session_response = await client.post("/session", json={"title": title})
+                self._raise_for_status(session_response, "create OpenCode session")
+                session_id = session_response.json().get("id")
+                if not session_id:
+                    raise OpenCodeError("OpenCode did not return a session id")
 
-            body: dict[str, Any] = {
-                "system": system_prompt,
-                "parts": [{"type": "text", "text": user_prompt}],
-            }
-            if model is not None:
-                body["model"] = model.as_payload()
+                body: dict[str, Any] = {
+                    "system": system_prompt,
+                    "parts": [{"type": "text", "text": user_prompt}],
+                }
+                if model is not None:
+                    body["model"] = model.as_payload()
 
-            message_response = await client.post(
-                f"/session/{session_id}/message",
-                json=body,
-            )
-            self._raise_for_status(message_response, "generate OpenCode message")
-            return self._extract_text(message_response.json())
+                message_response = await client.post(
+                    f"/session/{session_id}/message",
+                    json=body,
+                )
+                self._raise_for_status(message_response, "generate OpenCode message")
+                return self._extract_text(message_response.json())
+        except httpx.TransportError as e:
+            raise OpenCodeUnavailable("OpenCode server unavailable") from e
 
     def _auth(self) -> tuple[str, str] | None:
         password = os.getenv(OPENCODE_SERVER_PASSWORD_ENV_VAR, "")

--- a/src/core/workflow.py
+++ b/src/core/workflow.py
@@ -141,6 +141,10 @@ async def analyze_articles(
     # Analyze the filtered articles
     analysis_results = await analyze_exploitation(filtered_articles, config)
     state["analysis_results"] = analysis_results
+    if analysis_results.get("skipped"):
+        logger.warning(f"Analysis skipped: {analysis_results['skip_reason']}")
+        state["status"] = "completed_with_warnings"
+        return state
     if analysis_results.get("error"):
         logger.error(f"Analysis failed: {analysis_results['error']}")
         state["status"] = "failed"
@@ -160,6 +164,10 @@ async def generate_report(
 
     if not analysis_results:
         logger.warning("No analysis results to generate report")
+        state["status"] = "completed_with_warnings"
+        return state
+    if analysis_results.get("skipped"):
+        logger.warning(f"Skipping report generation: {analysis_results['skip_reason']}")
         state["status"] = "completed_with_warnings"
         return state
 
@@ -246,6 +254,10 @@ async def publish_results(
 
     if not analysis_results:
         logger.warning("No analysis results to publish")
+        state["status"] = "completed_with_warnings"
+        return state
+    if analysis_results.get("skipped"):
+        logger.warning(f"Skipping publishing: {analysis_results['skip_reason']}")
         state["status"] = "completed_with_warnings"
         return state
 

--- a/tests/test_analyze_guards.py
+++ b/tests/test_analyze_guards.py
@@ -76,6 +76,34 @@ class AnalyzeGuardTests(unittest.TestCase):
         self.assertNotIn("error", result)
         self.assertIn("Generated through OpenCode", result["exploitation_report"])
 
+    def test_unavailable_opencode_server_returns_skip_result(self):
+        analyze = import_analyze_with_stubs()
+
+        class FakeOpenCodeClient:
+            def __init__(self, **_kwargs):
+                pass
+
+            async def generate(self, **_kwargs):
+                raise analyze.OpenCodeUnavailable("OpenCode server unavailable")
+
+        analyze.OpenCodeClient = FakeOpenCodeClient
+
+        with patch.dict(os.environ, {}, clear=True):
+            result = asyncio.run(
+                analyze.analyze_exploitation(
+                    articles=[],
+                    config={
+                        "analysis": {
+                            "model": "openrouter/nvidia/nemotron-3-ultra-550b-a55b:free"
+                        }
+                    },
+                )
+            )
+
+        self.assertTrue(result["skipped"])
+        self.assertEqual(result["skip_reason"], "OpenCode server unavailable")
+        self.assertNotIn("error", result)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_opencode_client.py
+++ b/tests/test_opencode_client.py
@@ -4,7 +4,11 @@ import unittest
 
 import httpx
 
-from src.core.opencode_client import OpenCodeClient, parse_model_selection
+from src.core.opencode_client import (
+    OpenCodeUnavailable,
+    OpenCodeClient,
+    parse_model_selection,
+)
 
 
 class OpenCodeClientTests(unittest.TestCase):
@@ -73,6 +77,29 @@ class OpenCodeClientTests(unittest.TestCase):
             )
 
         self.assertNotIn("secret prompt fragment", str(raised.exception))
+
+    def test_generate_classifies_connection_failure_as_unavailable(self):
+        def handler(request):
+            raise httpx.ConnectError("secret connection detail", request=request)
+
+        client = OpenCodeClient(
+            base_url="http://opencode.test",
+            transport=httpx.MockTransport(handler),
+        )
+
+        with self.assertRaisesRegex(
+            OpenCodeUnavailable,
+            "OpenCode server unavailable",
+        ) as raised:
+            asyncio.run(
+                client.generate(
+                    system_prompt="system",
+                    user_prompt="user",
+                    model=parse_model_selection("openrouter/nex-agi/nex-n2-pro:free"),
+                )
+            )
+
+        self.assertNotIn("secret connection detail", str(raised.exception))
 
 
 if __name__ == "__main__":

--- a/tests/test_workflow_guards.py
+++ b/tests/test_workflow_guards.py
@@ -112,6 +112,26 @@ class WorkflowGuardTests(unittest.TestCase):
             self.assertIn("report_validation_errors", result)
             self.assertFalse(output_path.exists())
 
+    def test_skipped_analysis_does_not_write_output_file(self):
+        workflow = import_workflow_with_stubs()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "index.md"
+            state = {
+                "analysis_results": {
+                    "skipped": True,
+                    "skip_reason": "OpenCode server unavailable",
+                    "exploitation_report": "",
+                },
+                "config": {"output_path": str(output_path)},
+                "status": "started",
+            }
+
+            result = asyncio.run(workflow.generate_report(state))
+
+            self.assertEqual(result["status"], "completed_with_warnings")
+            self.assertFalse(output_path.exists())
+
     def test_failed_state_skips_audio_generation(self):
         workflow = import_workflow_with_stubs()
         state = {
@@ -134,6 +154,23 @@ class WorkflowGuardTests(unittest.TestCase):
         result = asyncio.run(workflow.publish_results(state))
 
         self.assertIs(result, state)
+
+    def test_skipped_analysis_skips_publish(self):
+        workflow = import_workflow_with_stubs()
+        state = {
+            "analysis_results": {
+                "skipped": True,
+                "skip_reason": "OpenCode server unavailable",
+                "exploitation_report": "",
+            },
+            "config": {"github_pages": {"enabled": True}},
+            "status": "completed_with_warnings",
+        }
+
+        result = asyncio.run(workflow.publish_results(state))
+
+        self.assertIs(result, state)
+        self.assertEqual(result["status"], "completed_with_warnings")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- classify OpenCode transport failures as unavailable model-server state
- skip report generation and publishing when the model server is unavailable
- keep HTTP model errors and invalid report output on the existing failure path

## Validation
- bash scripts/local_validation.sh