### PR TITLE
Preserve sparse feed entry defaults

### DIFF
--- a/src/services/fetch.py
+++ b/src/services/fetch.py
@@ -48,9 +48,9 @@ class SentryDigestFeedClient:
             for entry in feed.entries:
                 # Basic article info
                 article = {
-                    "title": entry.title,
-                    "link": entry.link,
-                    "summary": entry.description,
+                    "title": entry.get("title", ""),
+                    "link": entry.get("link", ""),
+                    "summary": entry.get("description", ""),
                     "published": entry.get("published", ""),
                     "source": entry.get("dc_source", "Unknown Source"),
                     "date": entry.get("dc_date", datetime.now().strftime("%Y-%m-%d")),

--- a/tests/test_feed_client.py
+++ b/tests/test_feed_client.py
@@ -1,0 +1,41 @@
+import asyncio
+from types import SimpleNamespace
+
+from src.services import fetch as fetch_module
+from src.services.fetch import SentryDigestFeedClient
+
+
+class FakeResponse:
+    text = "<rss><channel><item /></channel></rss>"
+
+    def raise_for_status(self):
+        pass
+
+
+class FakeHttpClient:
+    async def get(self, _url):
+        return FakeResponse()
+
+
+def test_fetch_articles_preserves_safe_defaults_for_sparse_feed_entries(monkeypatch):
+    monkeypatch.setattr(
+        fetch_module.feedparser,
+        "parse",
+        lambda _text: SimpleNamespace(entries=[{}]),
+    )
+    client = SentryDigestFeedClient("https://example.com/feed.xml")
+    client.client = FakeHttpClient()
+
+    articles = asyncio.run(client.fetch_articles())
+
+    assert articles == [
+        {
+            "title": "",
+            "link": "",
+            "summary": "",
+            "published": "",
+            "source": "Unknown Source",
+            "date": articles[0]["date"],
+            "content": "",
+        }
+    ]


### PR DESCRIPTION
## Summary
- Restore safe defaults for sparse RSS entry title, link, and description fields.
- Add a regression test for feed entries that omit optional metadata.

## Validation
- .                                                                        [100%]
1 passed in 0.11s
- All checks passed!
All checks passed!
..................................                                       [100%]
34 passed in 0.16s
Report content validation passed: index.md