### PR TITLE
Guard article enrichment without links

### DIFF
--- a/src/services/fetch.py
+++ b/src/services/fetch.py
@@ -98,14 +98,20 @@ class SentryDigestFeedClient:
             if "summary" in article and article["summary"]:
                 full_content += article["summary"] + "\n"
 
+            article_link = article.get("link", "")
+            if not article_link:
+                article["content"] = full_content
+                enriched_articles.append(article)
+                continue
+
             # Use async fetch for full article content
             try:
                 timeout = httpx.Timeout(10.0, connect=5.0)
                 async with httpx.AsyncClient(
                     timeout=timeout, follow_redirects=True
                 ) as client:
-                    logger.info(f"Fetching full content for: {article.get('link', '')}")
-                    response = await client.get(article.get("link", ""))
+                    logger.info(f"Fetching full content for: {article_link}")
+                    response = await client.get(article_link)
 
                     if response.status_code == 200:
                         # Add full article content

--- a/tests/test_feed_client.py
+++ b/tests/test_feed_client.py
@@ -17,6 +17,23 @@ class FakeHttpClient:
         return FakeResponse()
 
 
+class TrackingArticleClient:
+    called = False
+
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+    async def get(self, _url):
+        type(self).called = True
+        raise AssertionError("missing article links should not be fetched")
+
+
 def test_fetch_articles_preserves_safe_defaults_for_sparse_feed_entries(monkeypatch):
     monkeypatch.setattr(
         fetch_module.feedparser,
@@ -39,3 +56,25 @@ def test_fetch_articles_preserves_safe_defaults_for_sparse_feed_entries(monkeypa
             "content": "",
         }
     ]
+
+
+def test_enrich_article_content_skips_full_fetch_when_link_is_missing(monkeypatch):
+    TrackingArticleClient.called = False
+    monkeypatch.setattr(fetch_module.httpx, "AsyncClient", TrackingArticleClient)
+    client = SentryDigestFeedClient("https://example.com/feed.xml")
+
+    articles = asyncio.run(
+        client.enrich_article_content(
+            [
+                {
+                    "title": "Sparse article",
+                    "summary": "Summary only",
+                    "link": "",
+                    "content": "",
+                }
+            ]
+        )
+    )
+
+    assert articles[0]["content"] == "Sparse article\nSummary only\n"
+    assert TrackingArticleClient.called is False


### PR DESCRIPTION
## Summary
- Skip full-content fetches for feed articles without links.
- Add a regression test that confirms sparse articles use local title and summary content without an HTTP fetch.

## Validation
- ..                                                                       [100%]
2 passed in 0.48s
- All checks passed!
All checks passed!
...................................                                      [100%]
35 passed in 0.22s
Report content validation passed: index.md