### PR TITLE
Format sparse article source blocks

### DIFF
--- a/src/core/analyze.py
+++ b/src/core/analyze.py
@@ -70,6 +70,33 @@ def filter_exploitation_articles(
     return articles
 
 
+def format_article_summary(article: Dict[str, Any]) -> str:
+    def clean_text(value: Any, default: str = "") -> str:
+        if value is None:
+            return default
+        return str(value).strip()
+
+    title = clean_text(article.get("title"), "Untitled article") or "Untitled article"
+    source = clean_text(article.get("source"))
+    link = clean_text(article.get("link"))
+    content = clean_text(
+        article.get("content", article.get("summary")),
+        "No content available",
+    )
+
+    metadata = []
+    if source:
+        metadata.append(f"Source: {source}")
+    if link:
+        metadata.append(f"URL: {link}")
+
+    heading = f"**{title}**"
+    if metadata:
+        heading = f"{heading} ({'; '.join(metadata)})"
+
+    return f"{heading}\n\n{content[:500]}...\n\n"
+
+
 async def analyze_exploitation(
     articles: List[Dict[str, Any]], config: Dict[str, Any]
 ) -> Dict[str, Any]:
@@ -106,19 +133,7 @@ async def analyze_exploitation(
     all_attack_vectors = set()
 
     for article in articles:
-        # Get article metadata
-        title = article.get("title", "")
-        source = article.get("source", "")
-        link = article.get("link", "")
-
-        # Get article content or summary
-        content = article.get("content", article.get("summary", "No content available"))
-
-        # Create summary
-        summary = (
-            f"**{title}** (Source: {source})\n\nURL: {link}\n\n{content[:500]}...\n\n"
-        )
-        all_article_summaries.append(summary)
+        all_article_summaries.append(format_article_summary(article))
 
         # Extract CVEs and affected systems
         if "cves" in article:

--- a/tests/test_analyze_guards.py
+++ b/tests/test_analyze_guards.py
@@ -104,6 +104,44 @@ class AnalyzeGuardTests(unittest.TestCase):
         self.assertEqual(result["skip_reason"], "OpenCode server unavailable")
         self.assertNotIn("error", result)
 
+    def test_article_prompt_omits_empty_source_and_url_fields(self):
+        analyze = import_analyze_with_stubs()
+
+        class FakeOpenCodeClient:
+            def __init__(self, **_kwargs):
+                pass
+
+            async def generate(self, **kwargs):
+                user_prompt = kwargs["user_prompt"]
+                self.__class__.user_prompt = user_prompt
+                return "# Exploitation Report\n\nGenerated through OpenCode."
+
+        analyze.OpenCodeClient = FakeOpenCodeClient
+
+        with patch.dict(os.environ, {}, clear=True):
+            asyncio.run(
+                analyze.analyze_exploitation(
+                    articles=[
+                        {
+                            "title": None,
+                            "source": None,
+                            "link": None,
+                            "summary": "Summary only",
+                        }
+                    ],
+                    config={
+                        "analysis": {
+                            "model": "openrouter/nvidia/nemotron-3-ultra-550b-a55b:free"
+                        }
+                    },
+                )
+            )
+
+        self.assertIn("**Untitled article**", FakeOpenCodeClient.user_prompt)
+        self.assertIn("Summary only...", FakeOpenCodeClient.user_prompt)
+        self.assertNotIn("(Source: )", FakeOpenCodeClient.user_prompt)
+        self.assertNotIn("URL: \n", FakeOpenCodeClient.user_prompt)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Omit empty source and URL fields from article blocks in the analysis prompt.
- Add a regression test for sparse article metadata without a live model call.

## Validation
- ....                                                                     [100%]
4 passed in 0.02s
- All checks passed!
All checks passed!
....................................                                     [100%]
36 passed in 0.20s
Report content validation passed: index.md