### PR TITLE
Block active content in reports

### DIFF
--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -1,6 +1,9 @@
 """Validation rules for generated exploitation reports."""
 
 from dataclasses import dataclass
+import html
+from html.parser import HTMLParser
+import re
 from typing import Iterable, List
 
 REQUIRED_SECTIONS = (
@@ -23,11 +26,530 @@ ERROR_MARKERS = (
     "overloaded_error",
 )
 
+ACTIVE_CONTENT_MARKERS = (
+    "<script",
+    "</script",
+    "<iframe",
+    "<object",
+    "<embed",
+)
+
+MARKDOWN_ESCAPE_PATTERN = re.compile(r"\\([!\"#$%&'()*+,\-./:;<=>?@\[\]^_`{|}~])")
+MARKDOWN_LINK_DESTINATION_PATTERN = re.compile(
+    r"\]\(\s*(?P<destination><[^>\n]*>|[^)\s]+)"
+)
+MARKDOWN_REFERENCE_DESTINATION_PATTERN = re.compile(
+    r"^[ \t]{0,3}\[[^\]\n]+\]:[ \t]*(?P<destination><[^>\n]*>|[^\s]+)",
+    re.MULTILINE,
+)
+HTML_EVENT_ATTRIBUTE_PATTERN = re.compile(r"^on[a-z0-9_-]+$", re.IGNORECASE)
+LIST_ITEM_PATTERN = re.compile(r"^[ \t]{0,3}(?:[-+*]|\d+[.)])\s+")
+HTML_BLOCK_OPEN_PATTERN = re.compile(
+    r"^<(?P<tag>[A-Za-z][A-Za-z0-9:-]*)(?:\s|>|/)",
+    re.IGNORECASE,
+)
+HTML_BLOCK_CLOSE_PATTERN = re.compile(
+    r"^</(?P<tag>[A-Za-z][A-Za-z0-9:-]*)\s*>",
+    re.IGNORECASE,
+)
+URL_ATTRIBUTE_NAMES = {
+    "action",
+    "formaction",
+    "href",
+    "src",
+    "xlink:href",
+}
+VOID_HTML_TAGS = {
+    "area",
+    "base",
+    "br",
+    "col",
+    "embed",
+    "hr",
+    "img",
+    "input",
+    "link",
+    "meta",
+    "param",
+    "source",
+    "track",
+    "wbr",
+}
+ACTIVE_CONTENT_PATTERNS = (
+    re.compile(
+        r"j[\x00-\x20]*a[\x00-\x20]*v[\x00-\x20]*a[\x00-\x20]*"
+        r"s[\x00-\x20]*c[\x00-\x20]*r[\x00-\x20]*i[\x00-\x20]*"
+        r"p[\x00-\x20]*t[\x00-\x20]*:",
+        re.IGNORECASE,
+    ),
+)
+
 
 @dataclass(frozen=True)
 class ReportValidationIssue:
     code: str
     message: str
+
+
+class ActiveContentHTMLParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.has_active_content = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self._check_attrs(attrs)
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self._check_attrs(attrs)
+
+    def _check_attrs(self, attrs: list[tuple[str, str | None]]) -> None:
+        for name, value in attrs:
+            if HTML_EVENT_ATTRIBUTE_PATTERN.match(name):
+                self.has_active_content = True
+                return
+            if (
+                value is not None
+                and name.casefold() in URL_ATTRIBUTE_NAMES
+                and has_javascript_scheme(value)
+            ):
+                self.has_active_content = True
+                return
+
+
+def strip_markdown_code(markdown: str) -> str:
+    """Remove code regions before active-content validation."""
+    without_fenced_code = strip_fenced_code_blocks(markdown)
+    without_indented_code = strip_indented_code_blocks(without_fenced_code)
+    return strip_inline_code_spans(without_indented_code)
+
+
+def strip_fenced_code_blocks(markdown: str) -> str:
+    lines = markdown.splitlines(keepends=True)
+    output: list[str] = []
+    index = 0
+    html_block_stack: list[str] = []
+    list_content_indent: int | None = None
+
+    while index < len(lines):
+        line = lines[index]
+        stripped = line.strip()
+        line_content = line.rstrip("\r\n")
+        is_blank = not line_content.strip()
+        is_indented = line_content.startswith(" ") or line_content.startswith("\t")
+
+        max_fence_indent = (
+            list_content_indent + 4 if list_content_indent is not None else 3
+        )
+        if not html_block_stack and (
+            fence := parse_fence_opener(line, max_indent=max_fence_indent)
+        ):
+            index += 1
+            while index < len(lines) and not is_fence_closer(
+                lines[index],
+                fence,
+                max_indent=max_fence_indent,
+            ):
+                index += 1
+            if index < len(lines):
+                index += 1
+            continue
+
+        output.append(line)
+        update_html_block_stack(stripped, html_block_stack)
+        if (content_indent := list_item_content_indent(line_content)) is not None:
+            list_content_indent = content_indent
+        elif is_blank:
+            pass
+        elif not is_indented:
+            list_content_indent = None
+        index += 1
+
+    return "".join(output)
+
+
+def parse_fence_opener(line: str, max_indent: int = 3) -> str | None:
+    stripped = line.lstrip(" \t")
+    if indentation_columns(line) > max_indent:
+        return None
+
+    if stripped.startswith("```"):
+        fence = stripped[: len(stripped) - len(stripped.lstrip("`"))]
+        info = stripped[len(fence) :].strip()
+        if "`" in info:
+            return None
+        return fence
+
+    if stripped.startswith("~~~"):
+        return stripped[: len(stripped) - len(stripped.lstrip("~"))]
+
+    return None
+
+
+def is_fence_closer(line: str, opener: str, max_indent: int = 3) -> bool:
+    stripped = line.lstrip(" \t")
+    if indentation_columns(line) > max_indent:
+        return False
+
+    fence_character = opener[0]
+    closing_fence = stripped[: len(stripped) - len(stripped.lstrip(fence_character))]
+    if len(closing_fence) < len(opener):
+        return False
+
+    return not stripped[len(closing_fence) :].strip()
+
+
+def indentation_columns(line: str) -> int:
+    columns = 0
+    for character in line:
+        if character == " ":
+            columns += 1
+        elif character == "\t":
+            columns += 4 - (columns % 4)
+        else:
+            break
+    return columns
+
+
+def update_html_block_stack(stripped_line: str, stack: list[str]) -> None:
+    for tag_type, tag in iter_html_tags(stripped_line):
+        if tag_type == "close":
+            if stack and stack[-1] == tag:
+                stack.pop()
+        elif tag not in VOID_HTML_TAGS:
+            stack.append(tag)
+
+
+def iter_html_tags(markup: str) -> Iterable[tuple[str, str]]:
+    index = 0
+
+    while index < len(markup):
+        character = markup[index]
+        if character != "<":
+            index += 1
+            continue
+
+        tag_start = index + 1
+        tag_type = "open"
+        if tag_start < len(markup) and markup[tag_start] == "/":
+            tag_type = "close"
+            tag_start += 1
+
+        if tag_start >= len(markup) or not markup[tag_start].isalpha():
+            index += 1
+            continue
+
+        tag_end = tag_start
+        while tag_end < len(markup) and (
+            markup[tag_end].isalnum() or markup[tag_end] in ":-"
+        ):
+            tag_end += 1
+
+        tag = markup[tag_start:tag_end].casefold()
+        close_index = find_html_tag_close(markup, tag_end)
+        if close_index == -1:
+            index += 1
+            continue
+
+        tag_body = markup[tag_end:close_index].rstrip()
+        if tag_type == "open" and tag_body.endswith("/"):
+            tag_type = "selfclose"
+
+        yield tag_type, tag
+        index = close_index + 1
+
+
+def find_html_tag_close(markup: str, start: int) -> int:
+    quote: str | None = None
+    index = start
+
+    while index < len(markup):
+        character = markup[index]
+        if quote is not None:
+            if character == quote:
+                quote = None
+        elif character in ("'", '"'):
+            quote = character
+        elif character == ">":
+            return index
+
+        index += 1
+
+    return -1
+
+
+def visual_columns(text: str) -> int:
+    columns = 0
+    for character in text:
+        if character == "\t":
+            columns += 4 - (columns % 4)
+        else:
+            columns += 1
+
+    return columns
+
+
+def list_item_content_indent(line: str) -> int | None:
+    match = LIST_ITEM_PATTERN.match(line)
+    if match is None:
+        return None
+
+    return visual_columns(line[: match.end()])
+
+
+def strip_indented_code_blocks(markdown: str) -> str:
+    lines = markdown.splitlines(keepends=True)
+    output: list[str] = []
+    previous_blank = True
+    in_code_block = False
+    list_content_indent: int | None = None
+    html_block_stack: list[str] = []
+
+    for line in lines:
+        line_content = line.rstrip("\r\n")
+        stripped = line_content.strip()
+        is_blank = not line_content.strip()
+        is_indented = line_content.startswith("    ") or line_content.startswith("\t")
+        line_indent = indentation_columns(line_content)
+
+        if html_block_stack:
+            output.append(line)
+            update_html_block_stack(stripped, html_block_stack)
+            previous_blank = False
+            in_code_block = False
+            continue
+
+        if (
+            is_indented
+            and list_content_indent is not None
+            and line_indent >= list_content_indent + 4
+            and (previous_blank or in_code_block)
+        ):
+            in_code_block = True
+            previous_blank = False
+            continue
+
+        if is_indented and list_content_indent is not None:
+            output.append(line)
+            previous_blank = False
+            in_code_block = False
+            continue
+
+        if is_indented and (previous_blank or in_code_block):
+            in_code_block = True
+            previous_blank = False
+            continue
+
+        if starts_html_block(stripped):
+            output.append(line)
+            update_html_block_stack(stripped, html_block_stack)
+            previous_blank = False
+            in_code_block = False
+            continue
+
+        if is_blank:
+            output.append(line)
+            previous_blank = True
+            continue
+
+        output.append(line)
+        previous_blank = False
+        in_code_block = False
+        list_content_indent = list_item_content_indent(line_content)
+
+    return "".join(output)
+
+
+def strip_inline_code_spans(markdown: str) -> str:
+    lines = markdown.splitlines(keepends=True)
+    output: list[str] = []
+    html_block_stack: list[str] = []
+
+    for line in lines:
+        stripped = line.strip()
+        if html_block_stack or starts_html_block(stripped):
+            output.append(line)
+            update_html_block_stack(stripped, html_block_stack)
+            continue
+
+        output.append(strip_inline_code_spans_in_text(line))
+
+    return "".join(output)
+
+
+def strip_inline_code_spans_in_text(markdown: str) -> str:
+    output: list[str] = []
+    index = 0
+    inside_html_tag = False
+    html_quote: str | None = None
+
+    def starts_html_tag(position: int) -> bool:
+        if position + 1 >= len(markdown):
+            return False
+
+        next_character = markdown[position + 1]
+        return next_character.isalpha() or next_character in "/!?"
+
+    def append_and_track_html(characters: str, source_index: int | None = None) -> None:
+        nonlocal inside_html_tag, html_quote
+        for offset, character in enumerate(characters):
+            output.append(character)
+            if inside_html_tag:
+                if html_quote:
+                    if character == html_quote:
+                        html_quote = None
+                elif character in ('"', "'"):
+                    html_quote = character
+                elif character == ">":
+                    inside_html_tag = False
+            elif (
+                character == "<"
+                and source_index is not None
+                and starts_html_tag(source_index + offset)
+            ):
+                inside_html_tag = True
+
+    def is_escaped(position: int) -> bool:
+        backslash_count = 0
+        cursor = position - 1
+        while cursor >= 0 and markdown[cursor] == "\\":
+            backslash_count += 1
+            cursor -= 1
+        return bool(backslash_count % 2)
+
+    def find_closing_delimiter(delimiter: str, start: int) -> int:
+        search_index = start
+        while True:
+            candidate = markdown.find(delimiter, search_index)
+            if candidate == -1:
+                return -1
+
+            previous_is_backtick = candidate > 0 and markdown[candidate - 1] == "`"
+            next_index = candidate + len(delimiter)
+            next_is_backtick = (
+                next_index < len(markdown) and markdown[next_index] == "`"
+            )
+            if (
+                not previous_is_backtick
+                and not next_is_backtick
+                and not is_escaped(candidate)
+            ):
+                return candidate
+
+            search_index = candidate + 1
+
+    def is_fence_like_opener(position: int, delimiter_length: int) -> bool:
+        if delimiter_length < 3:
+            return False
+
+        line_start = markdown.rfind("\n", 0, position) + 1
+        prefix = markdown[line_start:position]
+        return len(prefix) <= 3 and prefix.strip(" \t") == ""
+
+    while index < len(markdown):
+        if markdown[index] != "`" or inside_html_tag or is_escaped(index):
+            append_and_track_html(markdown[index], index)
+            index += 1
+            continue
+
+        delimiter_length = 1
+        while (
+            index + delimiter_length < len(markdown)
+            and markdown[index + delimiter_length] == "`"
+        ):
+            delimiter_length += 1
+
+        if is_fence_like_opener(index, delimiter_length):
+            append_and_track_html("`" * delimiter_length, index)
+            index += delimiter_length
+            continue
+
+        delimiter = "`" * delimiter_length
+        closing_index = find_closing_delimiter(delimiter, index + delimiter_length)
+        if closing_index == -1:
+            append_and_track_html(delimiter, index)
+            index += delimiter_length
+            continue
+
+        index = closing_index + delimiter_length
+
+    return "".join(output)
+
+
+def normalize_markdown_escapes(markdown: str) -> str:
+    """Resolve Markdown punctuation escapes before rendered-content checks."""
+    return MARKDOWN_ESCAPE_PATTERN.sub(r"\1", markdown)
+
+
+def preserve_markdown_escaped_html(markdown: str) -> str:
+    lines = markdown.splitlines(keepends=True)
+    output: list[str] = []
+    html_block_stack: list[str] = []
+
+    for line in lines:
+        stripped = line.strip()
+        if html_block_stack or starts_html_block(stripped):
+            output.append(line)
+            update_html_block_stack(stripped, html_block_stack)
+        else:
+            output.append(preserve_markdown_escaped_html_in_text(line))
+
+    return "".join(output)
+
+
+def preserve_markdown_escaped_html_in_text(markdown: str) -> str:
+    output: list[str] = []
+    for index, character in enumerate(markdown):
+        if character in "<>" and has_odd_backslash_escape(markdown, index):
+            if output and output[-1] == "\\":
+                output.pop()
+            output.append("&lt;" if character == "<" else "&gt;")
+        else:
+            output.append(character)
+
+    return "".join(output)
+
+
+def has_odd_backslash_escape(markdown: str, position: int) -> bool:
+    backslash_count = 0
+    cursor = position - 1
+    while cursor >= 0 and markdown[cursor] == "\\":
+        backslash_count += 1
+        cursor -= 1
+
+    return bool(backslash_count % 2)
+
+
+def has_javascript_scheme(value: str) -> bool:
+    return any(pattern.search(value) for pattern in ACTIVE_CONTENT_PATTERNS)
+
+
+def starts_html_block(stripped_line: str) -> bool:
+    return bool(
+        HTML_BLOCK_OPEN_PATTERN.match(stripped_line)
+        or HTML_BLOCK_CLOSE_PATTERN.match(stripped_line)
+    )
+
+
+def contains_active_html(markup: str) -> bool:
+    parser = ActiveContentHTMLParser()
+    parser.feed(markup)
+    parser.close()
+    return parser.has_active_content
+
+
+def contains_active_markdown_link(markdown: str) -> bool:
+    matches = (
+        *MARKDOWN_LINK_DESTINATION_PATTERN.finditer(markdown),
+        *MARKDOWN_REFERENCE_DESTINATION_PATTERN.finditer(markdown),
+    )
+    for match in matches:
+        destination = match.group("destination")
+        if destination.startswith("<") and destination.endswith(">"):
+            destination = destination[1:-1]
+        if has_javascript_scheme(html.unescape(destination)):
+            return True
+
+    return False
 
 
 def validate_report_content(markdown: str) -> List[ReportValidationIssue]:
@@ -43,15 +565,54 @@ def validate_report_content(markdown: str) -> List[ReportValidationIssue]:
             )
         ]
 
-    normalized_content = content.casefold()
+    active_content = strip_markdown_code(content)
+    html_active_content = preserve_markdown_escaped_html(active_content)
+    rendered_like_content = normalize_markdown_escapes(active_content)
+    normalized_report_content = content.casefold()
+    normalized_content = html_active_content.casefold()
     for marker in ERROR_MARKERS:
-        if marker.casefold() in normalized_content:
+        if marker.casefold() in normalized_report_content:
             issues.append(
                 ReportValidationIssue(
                     code="error_marker",
                     message=f"Report contains blocked error marker: {marker}",
                 )
             )
+
+    for marker in ACTIVE_CONTENT_MARKERS:
+        if marker.casefold() in normalized_content:
+            issues.append(
+                ReportValidationIssue(
+                    code="active_content",
+                    message=f"Report contains blocked active content marker: {marker}",
+                )
+            )
+
+    if contains_active_html(html_active_content):
+        issues.append(
+            ReportValidationIssue(
+                code="active_content",
+                message="Report contains blocked active HTML event handler.",
+            )
+        )
+
+    has_active_markdown_link = contains_active_markdown_link(rendered_like_content)
+    for pattern in ACTIVE_CONTENT_PATTERNS:
+        if pattern.search(active_content) or pattern.search(rendered_like_content):
+            issues.append(
+                ReportValidationIssue(
+                    code="active_content",
+                    message="Report contains blocked JavaScript URL.",
+                )
+            )
+
+    if has_active_markdown_link:
+        issues.append(
+            ReportValidationIssue(
+                code="active_content",
+                message="Report contains blocked JavaScript URL.",
+            )
+        )
 
     for section in REQUIRED_SECTIONS:
         if section not in content:

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -45,6 +45,13 @@ class ReportValidationTests(unittest.TestCase):
 
         self.assertTrue(any(issue.code == "error_marker" for issue in issues))
 
+    def test_api_error_marker_in_code_block_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n```\n# Error\nError code: 404\n```\n"
+        )
+
+        self.assertTrue(any(issue.code == "error_marker" for issue in issues))
+
     def test_missing_required_section_fails(self):
         issues = validate_report_content("# Exploitation Report\n\nSummary only")
 
@@ -54,6 +61,298 @@ class ReportValidationTests(unittest.TestCase):
         issues = validate_report_content("")
 
         self.assertEqual(issues[0].code, "empty_report")
+
+    def test_script_tag_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n<script>alert('xss')</script>\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_javascript_link_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n[malicious link](javascript:alert('xss'))\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_entity_encoded_javascript_link_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT + '\n<a href="java&#115;cript:alert(1)">click</a>\n'
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_entity_encoded_markdown_javascript_link_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n[malicious link](java&#115;cript:alert('xss'))\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_entity_encoded_reference_javascript_link_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n[malicious link][x]\n\n[x]: java&#115;cript:alert(1)\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_entity_encoded_control_character_javascript_link_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT + '\n<a href="jav&#x09;ascript:alert(1)">click</a>\n'
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_markdown_escaped_javascript_link_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n[malicious link](javascript\\:alert('xss'))\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_inline_code_active_content_example_passes(self):
+        issues = validate_report_content(
+            VALID_REPORT
+            + "\nUse `javascript:alert(1)` as an example of a dangerous URL.\n"
+        )
+
+        self.assertEqual(issues, [])
+
+    def test_inline_code_after_less_than_text_passes(self):
+        issues = validate_report_content(
+            VALID_REPORT
+            + "\nWhen x < y, use `javascript:alert(1)` as a blocked URL example.\n"
+        )
+
+        self.assertEqual(issues, [])
+
+    def test_multi_backtick_inline_code_active_content_example_passes(self):
+        issues = validate_report_content(
+            VALID_REPORT
+            + "\nUse ``javascript:alert(1)`` as an example of a dangerous URL.\n"
+        )
+
+        self.assertEqual(issues, [])
+
+    def test_fenced_code_active_content_example_passes(self):
+        issues = validate_report_content(
+            VALID_REPORT
+            + "\n```html\n<script>alert('xss')</script>\n<img src=x onerror=alert(1)>\n```\n"
+        )
+
+        self.assertEqual(issues, [])
+
+    def test_list_nested_fenced_code_active_content_example_passes(self):
+        issues = validate_report_content(
+            VALID_REPORT
+            + "\n- Example\n\n    ```html\n    <script>alert('xss')</script>\n    ```\n"
+        )
+
+        self.assertEqual(issues, [])
+
+    def test_over_indented_list_fence_does_not_hide_active_html(self):
+        issues = validate_report_content(
+            VALID_REPORT
+            + "\n- Example\n\n       ```html\n<img src=x onerror=alert(1)>\n```\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_list_nested_fence_closer_does_not_hide_later_active_html(self):
+        issues = validate_report_content(
+            VALID_REPORT
+            + "\n- Example\n\n    ```html\n    <script>alert('safe')</script>\n    ```\n\n<img src=x onerror=alert(1)>\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_fenced_code_inside_raw_html_block_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT
+            + "\n<div>\n```html\n<img src=x onerror=alert(1)>\n```\n</div>\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_fenced_code_inside_custom_html_block_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT
+            + "\n<x-report>\n```html\n<img src=x onerror=alert(1)>\n```\n</x-report>\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_quoted_html_closer_does_not_end_raw_html_block(self):
+        issues = validate_report_content(
+            VALID_REPORT
+            + '\n<div title="</div>">\n```html\n<img src=x onerror=alert(1)>\n```\n</div>\n'
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_nested_html_openers_do_not_hide_active_html(self):
+        issues = validate_report_content(
+            VALID_REPORT
+            + "\n<div><div>\n</div>\n```html\n<img src=x onerror=alert(1)>\n```\n</div>\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_non_void_self_closing_html_block_does_not_hide_active_html(self):
+        issues = validate_report_content(
+            VALID_REPORT
+            + "\n<div/>\n```html\n<img src=x onerror=alert(1)>\n```\n</div>\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_invalid_backtick_fence_info_does_not_hide_active_html(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n``` `\n<img src=x onerror=alert(1)>\n```\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_tab_indented_fence_does_not_hide_active_html(self):
+        issues = validate_report_content(
+            VALID_REPORT
+            + "\nStandalone paragraph before the tab-indented opener.\n\n\t```html\n<img src=x onerror=alert(1)>\n```\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_tilde_fenced_code_active_content_example_passes(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n~~~html\n<script>alert('xss')</script>\n~~~\n"
+        )
+
+        self.assertEqual(issues, [])
+
+    def test_indented_code_active_content_example_passes(self):
+        issues = validate_report_content(
+            VALID_REPORT
+            + "\nParagraph before the code example.\n\n    <script>alert('xss')</script>\n"
+        )
+
+        self.assertEqual(issues, [])
+
+    def test_indented_html_after_paragraph_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\nIntro\n    <img src=x onerror=alert(1)>\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_indented_html_list_continuation_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n- item\n\n    <img src=x onerror=alert(1)>\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_list_nested_indented_code_active_content_example_passes(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n- Example\n\n        <script>alert('xss')</script>\n"
+        )
+
+        self.assertEqual(issues, [])
+
+    def test_html_event_handler_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n<img src=x onerror=alert(1)>\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_slash_separated_html_event_handler_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n<img/onerror=alert(1) src=x>\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_html_event_handler_after_quoted_angle_bracket_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT + '\n<img title=">" src=x onerror=alert(1)>\n'
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_html_event_handler_with_backtick_attributes_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT + '\n<img title="`" src=x onerror=alert(1) alt="`">\n'
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_html_event_handler_wrapped_in_escaped_backticks_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n\\` <img src=x onerror=alert(1)> \\`\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_html_event_handler_before_longer_backtick_run_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\nText ` <img src=x onerror=alert(1)> ``\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_inline_code_inside_raw_html_block_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n<div>\n`<img src=x onerror=alert(1)>`\n</div>\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_markdown_escaped_html_inside_raw_html_block_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n<div>\n\\<img src=x onerror=alert(1)>\n</div>\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_inline_code_after_void_html_tag_passes(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n<img src=x alt=test>\n`javascript:alert(1)`\n"
+        )
+
+        self.assertEqual(issues, [])
+
+    def test_svg_event_handler_fails(self):
+        issues = validate_report_content(VALID_REPORT + "\n<svg onload=alert(1)>\n")
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_entity_escaped_html_event_handler_example_passes(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n&lt;img src=x onerror=alert(1)&gt;\n"
+        )
+
+        self.assertEqual(issues, [])
+
+    def test_markdown_escaped_html_event_handler_example_passes(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n\\<img src=x onerror=alert(1)\\>\n"
+        )
+
+        self.assertEqual(issues, [])
+
+    def test_even_backslash_html_escape_does_not_hide_active_html(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n\\\\<img src=x onerror=alert(1)>\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_markdown_escaped_script_tag_example_passes(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n\\<script\\>alert(1)\\</script\\>\n"
+        )
+
+        self.assertEqual(issues, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Block active HTML and JavaScript URL markers during report validation.
- Add regression coverage for script tags and JavaScript links in generated markdown.

## Validation
- .......                                                                  [100%]
7 passed in 0.01s
- All checks passed!
All checks passed!
......................................                                   [100%]
38 passed in 0.19s
Report content validation passed: index.md