### PR TITLE
Fix residual report validation bypasses

### DIFF
--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -39,7 +39,8 @@ MARKDOWN_LINK_DESTINATION_PATTERN = re.compile(
     r"\]\(\s*(?P<destination><[^>\n]*>|[^)\s]+)"
 )
 MARKDOWN_REFERENCE_DESTINATION_PATTERN = re.compile(
-    r"^[ \t]{0,3}\[[^\]\n]+\]:[ \t]*(?P<destination><[^>\n]*>|[^\s]+)",
+    r"^[ \t]{0,3}\[[^\]\n]+\]:[ \t]*(?:\r?\n[ \t]*)?"
+    r"(?P<destination><[^>\n]*>|[^\s]+)",
     re.MULTILINE,
 )
 HTML_EVENT_ATTRIBUTE_PATTERN = re.compile(r"^on[a-z0-9_-]+$", re.IGNORECASE)
@@ -138,7 +139,7 @@ def strip_fenced_code_blocks(markdown: str) -> str:
         is_indented = line_content.startswith(" ") or line_content.startswith("\t")
 
         max_fence_indent = (
-            list_content_indent + 4 if list_content_indent is not None else 3
+            list_content_indent + 3 if list_content_indent is not None else 3
         )
         if not html_block_stack and (
             fence := parse_fence_opener(line, max_indent=max_fence_indent)

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -97,6 +97,20 @@ class ReportValidationTests(unittest.TestCase):
 
         self.assertTrue(any(issue.code == "active_content" for issue in issues))
 
+    def test_wrapped_reference_javascript_link_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n[malicious link][x]\n\n[x]:\n java&#115;cript:alert(1)\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_unindented_wrapped_reference_javascript_link_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n[malicious link][x]\n\n[x]:\njava&#115;cript:alert(1)\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
     def test_entity_encoded_control_character_javascript_link_fails(self):
         issues = validate_report_content(
             VALID_REPORT + '\n<a href="jav&#x09;ascript:alert(1)">click</a>\n'
@@ -155,6 +169,14 @@ class ReportValidationTests(unittest.TestCase):
         issues = validate_report_content(
             VALID_REPORT
             + "\n- Example\n\n       ```html\n<img src=x onerror=alert(1)>\n```\n"
+        )
+
+        self.assertTrue(any(issue.code == "active_content" for issue in issues))
+
+    def test_list_code_indented_fence_does_not_hide_active_html(self):
+        issues = validate_report_content(
+            VALID_REPORT
+            + "\n- Example\n\n      ```html\n<img src=x onerror=alert(1)>\n```\n"
         )
 
         self.assertTrue(any(issue.code == "active_content" for issue in issues))


### PR DESCRIPTION
## Summary
- Block wrapped reference-link JavaScript destinations during report validation.
- Tighten list-nested fence indentation so code-indented pseudo-fences cannot hide active HTML.

## Validation
- Report validation tests passed.
- Local validation passed.