### PR TITLE
Sanitize rendered report HTML

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/png" href="/SentryInsight/assets/logo.png">
     <link rel="shortcut icon" type="image/png" href="/SentryInsight/assets/logo.png">
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown.min.css">
     <style>
         :root {
@@ -622,7 +623,7 @@
           .then(response => response.text())
           .then(text => {
                 markdownCache = text;
-                let html = marked.parse(text);
+                let html = DOMPurify.sanitize(marked.parse(text));
                 contentEl.innerHTML = html;
 
                 // Extract executive summary (first paragraph after H1)

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="icon" type="image/png" href="/SentryInsight/assets/logo.png">
     <link rel="shortcut icon" type="image/png" href="/SentryInsight/assets/logo.png">
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown.min.css">
     <style>
         :root {
@@ -622,7 +623,7 @@
           .then(response => response.text())
           .then(text => {
                 markdownCache = text;
-                let html = marked.parse(text);
+                let html = DOMPurify.sanitize(marked.parse(text));
                 contentEl.innerHTML = html;
 
                 // Extract executive summary (first paragraph after H1)

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+REPORT_VIEWERS = (
+    Path("index.html"),
+    Path("docs/index.html"),
+)
+
+
+def test_report_viewers_sanitize_marked_output_before_rendering():
+    for viewer_path in REPORT_VIEWERS:
+        viewer = viewer_path.read_text()
+
+        assert "dompurify@3" in viewer
+        assert "DOMPurify.sanitize(marked.parse(text)" in viewer
+        assert "let html = marked.parse(text);" not in viewer


### PR DESCRIPTION
## Summary
- Sanitize Markdown-rendered report HTML before assigning it to the page.
- Add a static guard that requires both report viewer copies to use the sanitizer.

## Validation
- Focused viewer security test passed.
- Local validation passed.