### PR TITLE
Link CVEs without reparsing report HTML

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -502,9 +502,47 @@
         }
 
         function linkifyCVEs() {
-            const re = /CVE-\d{4}-\d{4,7}/g;
+            const cveTextPattern = /CVE-\d{4}-\d{4,7}/i;
+            const cveLinkPattern = /CVE-\d{4}-\d{4,7}/gi;
             contentEl.querySelectorAll('p, li').forEach(el => {
-                el.innerHTML = el.innerHTML.replace(re, (m) => `<a href="https://nvd.nist.gov/vuln/detail/${m}" target="_blank" rel="noopener">${m}</a>`);
+                const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, {
+                    acceptNode: (node) => {
+                        const parent = node.parentElement;
+                        if (!parent || parent.closest('a, code, pre')) {
+                            return NodeFilter.FILTER_REJECT;
+                        }
+                        return cveTextPattern.test(node.nodeValue)
+                            ? NodeFilter.FILTER_ACCEPT
+                            : NodeFilter.FILTER_SKIP;
+                    }
+                });
+                const textNodes = [];
+                let node = walker.nextNode();
+                while (node) {
+                    textNodes.push(node);
+                    node = walker.nextNode();
+                }
+                textNodes.forEach(textNode => {
+                    cveLinkPattern.lastIndex = 0;
+                    const fragment = document.createDocumentFragment();
+                    let lastIndex = 0;
+                    textNode.nodeValue.replace(cveLinkPattern, (match, offset) => {
+                        fragment.appendChild(
+                            document.createTextNode(textNode.nodeValue.slice(lastIndex, offset))
+                        );
+                        const link = document.createElement('a');
+                        link.href = `https://nvd.nist.gov/vuln/detail/${match}`;
+                        link.target = '_blank';
+                        link.rel = 'noopener';
+                        link.textContent = match;
+                        fragment.appendChild(link);
+                        lastIndex = offset + match.length;
+                    });
+                    fragment.appendChild(
+                        document.createTextNode(textNode.nodeValue.slice(lastIndex))
+                    );
+                    textNode.replaceWith(fragment);
+                });
             });
         }
 

--- a/index.html
+++ b/index.html
@@ -502,9 +502,47 @@
         }
 
         function linkifyCVEs() {
-            const re = /CVE-\d{4}-\d{4,7}/g;
+            const cveTextPattern = /CVE-\d{4}-\d{4,7}/i;
+            const cveLinkPattern = /CVE-\d{4}-\d{4,7}/gi;
             contentEl.querySelectorAll('p, li').forEach(el => {
-                el.innerHTML = el.innerHTML.replace(re, (m) => `<a href="https://nvd.nist.gov/vuln/detail/${m}" target="_blank" rel="noopener">${m}</a>`);
+                const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, {
+                    acceptNode: (node) => {
+                        const parent = node.parentElement;
+                        if (!parent || parent.closest('a, code, pre')) {
+                            return NodeFilter.FILTER_REJECT;
+                        }
+                        return cveTextPattern.test(node.nodeValue)
+                            ? NodeFilter.FILTER_ACCEPT
+                            : NodeFilter.FILTER_SKIP;
+                    }
+                });
+                const textNodes = [];
+                let node = walker.nextNode();
+                while (node) {
+                    textNodes.push(node);
+                    node = walker.nextNode();
+                }
+                textNodes.forEach(textNode => {
+                    cveLinkPattern.lastIndex = 0;
+                    const fragment = document.createDocumentFragment();
+                    let lastIndex = 0;
+                    textNode.nodeValue.replace(cveLinkPattern, (match, offset) => {
+                        fragment.appendChild(
+                            document.createTextNode(textNode.nodeValue.slice(lastIndex, offset))
+                        );
+                        const link = document.createElement('a');
+                        link.href = `https://nvd.nist.gov/vuln/detail/${match}`;
+                        link.target = '_blank';
+                        link.rel = 'noopener';
+                        link.textContent = match;
+                        fragment.appendChild(link);
+                        lastIndex = offset + match.length;
+                    });
+                    fragment.appendChild(
+                        document.createTextNode(textNode.nodeValue.slice(lastIndex))
+                    );
+                    textNode.replaceWith(fragment);
+                });
             });
         }
 

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -13,3 +13,11 @@ def test_report_viewers_sanitize_marked_output_before_rendering():
         assert "dompurify@3" in viewer
         assert "DOMPurify.sanitize(marked.parse(text)" in viewer
         assert "let html = marked.parse(text);" not in viewer
+
+
+def test_report_viewers_do_not_rewrite_sanitized_report_html_for_cve_links():
+    for viewer_path in REPORT_VIEWERS:
+        viewer = viewer_path.read_text()
+
+        assert "document.createTreeWalker" in viewer
+        assert "el.innerHTML = el.innerHTML.replace" not in viewer


### PR DESCRIPTION
## Summary
- Link CVE references by replacing text nodes instead of rewriting sanitized HTML.
- Keep code and preformatted examples out of automatic CVE linkification.
- Add a viewer guard that blocks the older innerHTML replacement pattern.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_viewer_security.py -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`