### PR TITLE
Validate docs report artifact

### DIFF
--- a/.github/workflows/generate-report.yml
+++ b/.github/workflows/generate-report.yml
@@ -48,7 +48,9 @@ jobs:
           GOOGLE_TI_API_KEY: ${{ secrets.GOOGLE_TI_API_KEY }}
       
       - name: Validate report content before publishing
-        run: uv run python scripts/validate_report.py index.md
+        run: |
+          uv run python scripts/validate_report.py index.md
+          uv run python scripts/validate_report.py docs/index.md
 
       - name: Commit and push updated report
         if: github.ref == 'refs/heads/main'

--- a/scripts/local_validation.sh
+++ b/scripts/local_validation.sh
@@ -11,3 +11,4 @@ uv run black --check .
 uv run ty check
 uv run python -B -W error -m pytest tests -q -p no:cacheprovider
 uv run python -B scripts/validate_report.py index.md
+uv run python -B scripts/validate_report.py docs/index.md

--- a/tests/test_validation_gate_contract.py
+++ b/tests/test_validation_gate_contract.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_local_validation_checks_root_and_docs_report_markdown():
+    script = (REPO_ROOT / "scripts" / "local_validation.sh").read_text()
+
+    assert "scripts/validate_report.py index.md" in script
+    assert "scripts/validate_report.py docs/index.md" in script
+
+
+def test_generate_report_workflow_checks_root_and_docs_report_markdown():
+    workflow = (REPO_ROOT / ".github" / "workflows" / "generate-report.yml").read_text()
+
+    assert "scripts/validate_report.py index.md" in workflow
+    assert "scripts/validate_report.py docs/index.md" in workflow


### PR DESCRIPTION
## Summary
- Validate both generated report markdown files in the local gate.
- Run the same docs report validation before the workflow commits generated artifacts.
- Add a contract test that pins both validation surfaces.

## Validation
- `uv run python -B -W error -m pytest tests/test_validation_gate_contract.py -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`