### PR TITLE
Add report summary cards

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -387,10 +387,10 @@
             <aside id="toc">
                 <h4>On this page</h4>
                 <nav id="toc-list"></nav>
-                <div id="summary" class="summary"></div>
             </aside>
             <main>
                 <div class="meta" id="meta"></div>
+                <div id="summary" class="summary"></div>
                 <div id="exec" class="exec"></div>
                 <div id="content" class="markdown-body"></div>
             </main>
@@ -668,6 +668,9 @@
 
             const html = `
                 <div class="card"><h5>CVEs Mentioned</h5><div class="value">${uniqueCVEs.length}</div><div class="chips">${uniqueCVEs.slice(0,6).map(c => `<a class="chip" href="https://nvd.nist.gov/vuln/detail/${c}" target="_blank" rel="noopener">${c}</a>`).join('')}</div></div>
+                <div class="card"><h5>Active Items</h5><div class="value">${activeCount}</div></div>
+                <div class="card"><h5>Affected Products</h5><div class="value">${products}</div></div>
+                <div class="card"><h5>Report Sections</h5><div class="value">${sections}</div></div>
             `;
             summaryEl.innerHTML = html;
         }

--- a/index.html
+++ b/index.html
@@ -387,10 +387,10 @@
             <aside id="toc">
                 <h4>On this page</h4>
                 <nav id="toc-list"></nav>
-                <div id="summary" class="summary"></div>
             </aside>
             <main>
                 <div class="meta" id="meta"></div>
+                <div id="summary" class="summary"></div>
                 <div id="exec" class="exec"></div>
                 <div id="content" class="markdown-body"></div>
             </main>
@@ -668,6 +668,9 @@
 
             const html = `
                 <div class="card"><h5>CVEs Mentioned</h5><div class="value">${uniqueCVEs.length}</div><div class="chips">${uniqueCVEs.slice(0,6).map(c => `<a class="chip" href="https://nvd.nist.gov/vuln/detail/${c}" target="_blank" rel="noopener">${c}</a>`).join('')}</div></div>
+                <div class="card"><h5>Active Items</h5><div class="value">${activeCount}</div></div>
+                <div class="card"><h5>Affected Products</h5><div class="value">${products}</div></div>
+                <div class="card"><h5>Report Sections</h5><div class="value">${sections}</div></div>
             `;
             summaryEl.innerHTML = html;
         }

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -44,3 +44,17 @@ def test_report_viewers_include_mobile_overflow_guards():
         )
         assert "aside#toc { display: none; width: 100%; overflow-x: hidden; }" in viewer
         assert "#content { padding: 1.25em;" in viewer
+
+
+def test_report_viewers_render_full_summary_cards():
+    for viewer_path in REPORT_VIEWERS:
+        viewer = viewer_path.read_text()
+
+        assert (
+            '<div class="meta" id="meta"></div>\n                <div id="summary" class="summary"></div>'
+            in viewer
+        )
+        assert "CVEs Mentioned" in viewer
+        assert "Active Items" in viewer
+        assert "Affected Products" in viewer
+        assert "Report Sections" in viewer


### PR DESCRIPTION
## Summary
- Render the existing report summary metrics as visible cards in the reader.
- Move the summary strip into the main report column so it remains visible on mobile.
- Add a viewer guard for the full summary card set.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_viewer_security.py -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`