### PR TITLE
Add report archive link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -420,6 +420,7 @@
             </div>
             <div class="spacer"></div>
             <div class="toolbar">
+                <a id="archive-link" class="btn" href="reports/" hidden>Archive</a>
                 <button id="toggle-dark" class="btn" title="Toggle theme">Theme</button>
             </div>
         </header>
@@ -450,6 +451,7 @@
         const metaEl = document.getElementById('meta');
         const summaryEl = document.getElementById('summary');
         const toggleDarkEl = document.getElementById('toggle-dark');
+        const archiveLinkEl = document.getElementById('archive-link');
         const execEl = document.getElementById('exec');
         const sectionFilterEl = document.getElementById('section-filter');
         const sectionFilterCountEl = document.getElementById('section-filter-count');
@@ -459,6 +461,7 @@
         contentEl.innerHTML = '<div class="loading">Loading exploitation report...</div>';
         const preferDark = localStorage.getItem('sentryinsight:theme') === 'dark' || (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
         if (preferDark) document.body.classList.add('dark');
+        resolveArchiveLink();
 
         // Optional UI config for easier customization
         let UI_CONF = null;
@@ -466,6 +469,28 @@
 
         function slugify(text) {
             return text.toLowerCase().replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-').substring(0, 80);
+        }
+
+        function resolveArchiveLink() {
+            const candidates = ['reports/', 'docs/reports/'];
+            function probe(index) {
+                if (index >= candidates.length) {
+                    archiveLinkEl.hidden = true;
+                    return;
+                }
+                const url = candidates[index];
+                fetch(url, { method: 'HEAD', cache: 'no-store' })
+                    .then(response => {
+                        if (!response.ok) {
+                            probe(index + 1);
+                            return;
+                        }
+                        archiveLinkEl.href = url;
+                        archiveLinkEl.hidden = false;
+                    })
+                    .catch(() => probe(index + 1));
+            }
+            probe(0);
         }
 
         function addHeadingAnchors() {

--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SentryInsight Report Archive</title>
+    <style>
+        :root {
+            --bg: #f8fafc;
+            --panel: #ffffff;
+            --text: #0f172a;
+            --muted: #475569;
+            --border: #e2e8f0;
+            --accent: #b91c1c;
+        }
+        * { box-sizing: border-box; }
+        body {
+            margin: 0;
+            background: var(--bg);
+            color: var(--text);
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            line-height: 1.6;
+        }
+        main {
+            width: min(960px, calc(100vw - 32px));
+            margin: 0 auto;
+            padding: 40px 0;
+        }
+        header {
+            display: flex;
+            justify-content: space-between;
+            gap: 16px;
+            align-items: center;
+            margin-bottom: 24px;
+        }
+        h1 {
+            margin: 0;
+            font-size: clamp(1.75rem, 5vw, 2.5rem);
+            line-height: 1.1;
+        }
+        p {
+            color: var(--muted);
+            margin: 8px 0 0;
+        }
+        a {
+            color: var(--accent);
+            font-weight: 600;
+            text-decoration: none;
+        }
+        a:hover { text-decoration: underline; }
+        .back {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            color: var(--text);
+            padding: 8px 12px;
+            white-space: nowrap;
+        }
+        .archive-list {
+            display: grid;
+            gap: 12px;
+            margin-top: 16px;
+        }
+        .archive-item {
+            background: var(--panel);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 16px;
+        }
+        .archive-item h2 {
+            font-size: 1.1rem;
+            margin: 0 0 4px;
+        }
+        .archive-item p { margin: 0; }
+        @media (max-width: 560px) {
+            header {
+                align-items: flex-start;
+                flex-direction: column;
+            }
+            .back { width: 100%; text-align: center; }
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <header>
+            <div>
+                <h1>Report Archive</h1>
+                <p>Previous SentryInsight exploitation reports.</p>
+            </div>
+            <a class="back" href="../index.html">Latest report</a>
+        </header>
+        <section class="archive-list" aria-label="Available reports">
+            <article class="archive-item">
+                <h2><a href="index.md">Exploitation report archive entry</a></h2>
+                <p>Archived report artifact preserved from the generated report output.</p>
+            </article>
+        </section>
+    </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -420,6 +420,7 @@
             </div>
             <div class="spacer"></div>
             <div class="toolbar">
+                <a id="archive-link" class="btn" href="reports/" hidden>Archive</a>
                 <button id="toggle-dark" class="btn" title="Toggle theme">Theme</button>
             </div>
         </header>
@@ -450,6 +451,7 @@
         const metaEl = document.getElementById('meta');
         const summaryEl = document.getElementById('summary');
         const toggleDarkEl = document.getElementById('toggle-dark');
+        const archiveLinkEl = document.getElementById('archive-link');
         const execEl = document.getElementById('exec');
         const sectionFilterEl = document.getElementById('section-filter');
         const sectionFilterCountEl = document.getElementById('section-filter-count');
@@ -459,6 +461,7 @@
         contentEl.innerHTML = '<div class="loading">Loading exploitation report...</div>';
         const preferDark = localStorage.getItem('sentryinsight:theme') === 'dark' || (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
         if (preferDark) document.body.classList.add('dark');
+        resolveArchiveLink();
 
         // Optional UI config for easier customization
         let UI_CONF = null;
@@ -466,6 +469,28 @@
 
         function slugify(text) {
             return text.toLowerCase().replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-').substring(0, 80);
+        }
+
+        function resolveArchiveLink() {
+            const candidates = ['reports/', 'docs/reports/'];
+            function probe(index) {
+                if (index >= candidates.length) {
+                    archiveLinkEl.hidden = true;
+                    return;
+                }
+                const url = candidates[index];
+                fetch(url, { method: 'HEAD', cache: 'no-store' })
+                    .then(response => {
+                        if (!response.ok) {
+                            probe(index + 1);
+                            return;
+                        }
+                        archiveLinkEl.href = url;
+                        archiveLinkEl.hidden = false;
+                    })
+                    .catch(() => probe(index + 1));
+            }
+            probe(0);
         }
 
         function addHeadingAnchors() {

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -4,6 +4,7 @@ REPORT_VIEWERS = (
     Path("index.html"),
     Path("docs/index.html"),
 )
+ARCHIVE_INDEX = Path("docs/reports/index.html")
 
 
 def test_report_viewers_sanitize_marked_output_before_rendering():
@@ -77,3 +78,25 @@ def test_report_viewers_include_section_filter_controls():
         assert "contentEl.querySelectorAll('.section-collapsible')" in viewer
         assert "section-filter-hidden" in viewer
         assert "sectionFilterEl.addEventListener('input', filterSections)" in viewer
+
+
+def test_report_viewers_include_archive_navigation_affordance():
+    for viewer_path in REPORT_VIEWERS:
+        viewer = viewer_path.read_text()
+
+        assert 'id="archive-link"' in viewer
+        assert "resolveArchiveLink" in viewer
+        assert "reports/" in viewer
+        assert "docs/reports/" in viewer
+        assert "Promise.any" not in viewer
+        assert "function probe(index)" in viewer
+        assert "probe(index + 1)" in viewer
+        assert "archiveLinkEl.hidden = false" in viewer
+
+
+def test_report_archive_route_has_static_index():
+    archive = ARCHIVE_INDEX.read_text()
+
+    assert "Report Archive" in archive
+    assert "../index.html" in archive
+    assert "index.md" in archive


### PR DESCRIPTION
## Summary
- Add an Archive toolbar link to the report viewer.
- Resolve the link against the deployed reports route with a local preview fallback.
- Guard the archive affordance in the viewer test.

## Validation
- `bash scripts/local_validation.sh` started and cleared dependency sync/Ruff before the local Python runtime stalled.
- Direct viewer guard execution passed.
- `git diff --check`
- `uv run ty check`
- `uv run python -B scripts/validate_report.py index.md`
- `uv run python -B scripts/validate_report.py docs/index.md`