### PR TITLE
Require report source attribution

### DIFF
--- a/src/core/analyze.py
+++ b/src/core/analyze.py
@@ -97,6 +97,35 @@ def format_article_summary(article: Dict[str, Any]) -> str:
     return f"{heading}\n\n{content[:500]}...\n\n"
 
 
+def article_source_metadata_available(articles: list[Dict[str, Any]]) -> bool:
+    return any(article.get("source") or article.get("link") for article in articles)
+
+
+def collect_source_attribution_markers(articles: list[Dict[str, Any]]) -> list[str]:
+    markers = {
+        str(value).strip()
+        for article in articles
+        for value in (article.get("source"), article.get("link"))
+        if value and str(value).strip()
+    }
+    return sorted(markers)
+
+
+def collect_source_attribution_marker_groups(
+    articles: list[Dict[str, Any]],
+) -> list[list[str]]:
+    groups = []
+    for article in articles:
+        markers = [
+            str(value).strip()
+            for value in (article.get("source"), article.get("link"))
+            if value and str(value).strip()
+        ]
+        if markers:
+            groups.append(markers)
+    return groups
+
+
 async def analyze_exploitation(
     articles: List[Dict[str, Any]], config: Dict[str, Any]
 ) -> Dict[str, Any]:
@@ -188,6 +217,13 @@ Generate a report following this EXACT structure with professional markdown form
 - **Campaign**: Operation descriptions and impacts
 ]
 
+## Source Attribution
+
+[List the source articles used for this report:
+- **Article Title**: Source name - URL
+Only use source names and URLs provided in the article metadata. Do not invent
+or infer sources.]
+
 Formatting requirements:
 - Use proper markdown with **bold** for emphasis
 - Create clear bullet points with good spacing
@@ -195,6 +231,7 @@ Formatting requirements:
 - Write professional, well-structured content
 - Only mention CVE IDs when they are actually provided in the source articles
 - Do NOT mention missing or unavailable CVE information
+- Include the Source Attribution section when article source metadata or URLs are available
 
 Focus specifically on:
 - Zero-day vulnerabilities being actively exploited
@@ -224,11 +261,18 @@ Generate a well-formatted exploitation report following the structure above. Be 
             title="SentryInsight exploitation report",
         )
 
+        source_attribution_groups = collect_source_attribution_marker_groups(articles)
+        source_attribution_markers = sorted(
+            {marker for group in source_attribution_groups for marker in group}
+        )
         return {
             "exploitation_report": exploitation_report,
             "date": datetime.now().strftime("%Y-%m-%d"),
             "analyzed_article_count": len(articles),
             "cves_identified": list(all_cves),
+            "source_attribution_required": bool(source_attribution_markers),
+            "source_attribution_groups": source_attribution_groups,
+            "source_attribution_markers": source_attribution_markers,
         }
     except OpenCodeUnavailable as e:
         logger.warning(f"Skipping exploitation analysis: {e}")

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -13,6 +13,7 @@ REQUIRED_SECTIONS = (
     "## Attack Vectors and Techniques",
     "## Threat Actor Activities",
 )
+SOURCE_ATTRIBUTION_SECTION = "## Source Attribution"
 
 ERROR_MARKERS = (
     "# Error",
@@ -84,6 +85,7 @@ ACTIVE_CONTENT_PATTERNS = (
         re.IGNORECASE,
     ),
 )
+URL_PATTERN = re.compile(r"https?://\S+", re.IGNORECASE)
 
 
 @dataclass(frozen=True)
@@ -553,7 +555,64 @@ def contains_active_markdown_link(markdown: str) -> bool:
     return False
 
 
-def validate_report_content(markdown: str) -> List[ReportValidationIssue]:
+def get_source_attribution_section_body(markdown: str) -> str:
+    section_start = markdown.find(SOURCE_ATTRIBUTION_SECTION)
+    if section_start == -1:
+        return ""
+
+    section_body_start = section_start + len(SOURCE_ATTRIBUTION_SECTION)
+    next_section = re.search(r"^##\s+", markdown[section_body_start:], re.MULTILINE)
+    return (
+        markdown[section_body_start : section_body_start + next_section.start()]
+        if next_section
+        else markdown[section_body_start:]
+    )
+
+
+def source_attribution_section_has_entry(markdown: str) -> bool:
+    section_body = get_source_attribution_section_body(markdown)
+    for line in section_body.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if LIST_ITEM_PATTERN.match(stripped) or URL_PATTERN.search(stripped):
+            return True
+
+    return False
+
+
+def source_attribution_section_matches_marker(
+    markdown: str, source_attribution_markers: Iterable[str]
+) -> bool:
+    section_body = get_source_attribution_section_body(markdown).casefold()
+    return any(
+        marker.strip().casefold() in section_body
+        for marker in source_attribution_markers
+        if marker and marker.strip()
+    )
+
+
+def source_attribution_section_matches_groups(
+    markdown: str, source_attribution_groups: Iterable[Iterable[str]]
+) -> bool:
+    section_body = get_source_attribution_section_body(markdown).casefold()
+    groups = [
+        [marker.strip().casefold() for marker in group if marker and marker.strip()]
+        for group in source_attribution_groups
+    ]
+    groups = [group for group in groups if group]
+    if not groups:
+        return False
+
+    return all(any(marker in section_body for marker in group) for group in groups)
+
+
+def validate_report_content(
+    markdown: str,
+    require_source_attribution: bool = False,
+    source_attribution_markers: Iterable[str] | None = None,
+    source_attribution_groups: Iterable[Iterable[str]] | None = None,
+) -> List[ReportValidationIssue]:
     """Return validation issues that should block publishing."""
     issues: List[ReportValidationIssue] = []
     content = markdown.strip()
@@ -623,6 +682,27 @@ def validate_report_content(markdown: str) -> List[ReportValidationIssue]:
                     message=f"Report is missing required section: {section}",
                 )
             )
+
+    if source_attribution_groups:
+        has_expected_source_attribution = source_attribution_section_matches_groups(
+            content, source_attribution_groups
+        )
+    elif source_attribution_markers:
+        has_expected_source_attribution = source_attribution_section_matches_marker(
+            content, source_attribution_markers
+        )
+    else:
+        has_expected_source_attribution = source_attribution_section_has_entry(content)
+    if require_source_attribution and not has_expected_source_attribution:
+        issues.append(
+            ReportValidationIssue(
+                code="missing_source_attribution",
+                message=(
+                    "Report is missing required source attribution entries in section: "
+                    f"{SOURCE_ATTRIBUTION_SECTION}"
+                ),
+            )
+        )
 
     return issues
 

--- a/src/core/workflow.py
+++ b/src/core/workflow.py
@@ -161,7 +161,14 @@ async def generate_report(
     # Since the exploitation_report already contains the full formatted report,
     # we should use it directly instead of the template
     report = exploitation_report
-    validation_issues = validate_report_content(report)
+    validation_issues = validate_report_content(
+        report,
+        require_source_attribution=bool(
+            analysis_results.get("source_attribution_required")
+        ),
+        source_attribution_markers=analysis_results.get("source_attribution_markers"),
+        source_attribution_groups=analysis_results.get("source_attribution_groups"),
+    )
     if validation_issues:
         logger.error(
             "Report validation failed:\n%s",

--- a/src/services/publish.py
+++ b/src/services/publish.py
@@ -45,7 +45,16 @@ async def publish_to_github_pages(
             "exploitation_report", "No exploitation report available."
         )
         report_date = analysis_results.get("date", datetime.now().strftime("%Y-%m-%d"))
-        validation_issues = validate_report_content(exploitation_report)
+        validation_issues = validate_report_content(
+            exploitation_report,
+            require_source_attribution=bool(
+                analysis_results.get("source_attribution_required")
+            ),
+            source_attribution_markers=analysis_results.get(
+                "source_attribution_markers"
+            ),
+            source_attribution_groups=analysis_results.get("source_attribution_groups"),
+        )
         if validation_issues:
             logger.error(
                 "Refusing to publish invalid report:\n%s",

--- a/tests/test_analyze_guards.py
+++ b/tests/test_analyze_guards.py
@@ -142,6 +142,90 @@ class AnalyzeGuardTests(unittest.TestCase):
         self.assertNotIn("(Source: )", FakeOpenCodeClient.user_prompt)
         self.assertNotIn("URL: \n", FakeOpenCodeClient.user_prompt)
 
+    def test_prompt_requires_source_attribution_from_article_metadata(self):
+        analyze = import_analyze_with_stubs()
+
+        class FakeOpenCodeClient:
+            def __init__(self, **_kwargs):
+                pass
+
+            async def generate(self, **kwargs):
+                user_prompt = kwargs["user_prompt"]
+                self.__class__.user_prompt = user_prompt
+                return "# Exploitation Report\n\nGenerated through OpenCode."
+
+        analyze.OpenCodeClient = FakeOpenCodeClient
+
+        with patch.dict(os.environ, {}, clear=True):
+            asyncio.run(
+                analyze.analyze_exploitation(
+                    articles=[
+                        {
+                            "title": "Example exploitation report",
+                            "source": "Example Source",
+                            "link": "https://example.test/report",
+                            "summary": "Attackers exploited an exposed service.",
+                        }
+                    ],
+                    config={
+                        "analysis": {
+                            "model": "openrouter/nvidia/nemotron-3-ultra-550b-a55b:free"
+                        }
+                    },
+                )
+            )
+
+        self.assertIn("## Source Attribution", FakeOpenCodeClient.user_prompt)
+        self.assertIn(
+            "Only use source names and URLs provided",
+            FakeOpenCodeClient.user_prompt,
+        )
+        self.assertIn("Source: Example Source", FakeOpenCodeClient.user_prompt)
+        self.assertIn(
+            "URL: https://example.test/report", FakeOpenCodeClient.user_prompt
+        )
+
+    def test_analysis_result_requires_source_attribution_when_metadata_exists(self):
+        analyze = import_analyze_with_stubs()
+
+        class FakeOpenCodeClient:
+            def __init__(self, **_kwargs):
+                pass
+
+            async def generate(self, **_kwargs):
+                return "# Exploitation Report\n\nGenerated through OpenCode."
+
+        analyze.OpenCodeClient = FakeOpenCodeClient
+
+        with patch.dict(os.environ, {}, clear=True):
+            result = asyncio.run(
+                analyze.analyze_exploitation(
+                    articles=[
+                        {
+                            "title": "Example exploitation report",
+                            "source": "Example Source",
+                            "link": "https://example.test/report",
+                            "summary": "Attackers exploited an exposed service.",
+                        }
+                    ],
+                    config={
+                        "analysis": {
+                            "model": "openrouter/nvidia/nemotron-3-ultra-550b-a55b:free"
+                        }
+                    },
+                )
+            )
+
+        self.assertTrue(result["source_attribution_required"])
+        self.assertEqual(
+            result["source_attribution_markers"],
+            ["Example Source", "https://example.test/report"],
+        )
+        self.assertEqual(
+            result["source_attribution_groups"],
+            [["Example Source", "https://example.test/report"]],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_publish_guards.py
+++ b/tests/test_publish_guards.py
@@ -51,6 +51,31 @@ class PublishGuardTests(unittest.TestCase):
             self.assertTrue(repo_dir.exists())
             self.assertFalse((repo_dir / "index.md").exists())
 
+    def test_missing_required_source_attribution_is_not_published(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_dir = Path(tmpdir) / "docs"
+            result = asyncio.run(
+                publish_to_github_pages(
+                    {
+                        "exploitation_report": VALID_REPORT,
+                        "date": "2026-06-17",
+                        "source_attribution_required": True,
+                        "source_attribution_markers": [
+                            "Example Source",
+                            "https://example.test/report",
+                        ],
+                        "source_attribution_groups": [
+                            ["Example Source", "https://example.test/report"]
+                        ],
+                    },
+                    {"enabled": True, "repo_directory": str(repo_dir)},
+                )
+            )
+
+            self.assertFalse(result)
+            self.assertTrue(repo_dir.exists())
+            self.assertFalse((repo_dir / "index.md").exists())
+
     def test_valid_report_writes_pages_files(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             repo_dir = Path(tmpdir) / "docs"

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -26,10 +26,124 @@ Recent exploitation activity is concentrated in edge systems.
 - **Unknown actor**: Opportunistic exploitation.
 """
 
+VALID_REPORT_WITH_SOURCE_ATTRIBUTION = VALID_REPORT + """
+## Source Attribution
+
+- **Example Vulnerability Report**: Example Source - https://example.test/report
+"""
+
 
 class ReportValidationTests(unittest.TestCase):
     def test_valid_report_passes(self):
         self.assertEqual(validate_report_content(VALID_REPORT), [])
+
+    def test_missing_source_attribution_fails_when_required(self):
+        issues = validate_report_content(VALID_REPORT, require_source_attribution=True)
+
+        self.assertTrue(
+            any(issue.code == "missing_source_attribution" for issue in issues)
+        )
+
+    def test_empty_source_attribution_section_fails_when_required(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n## Source Attribution\n\n",
+            require_source_attribution=True,
+        )
+
+        self.assertTrue(
+            any(issue.code == "missing_source_attribution" for issue in issues)
+        )
+
+    def test_source_attribution_section_without_entry_fails_when_required(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n## Source Attribution\n\nNo sources were provided.\n",
+            require_source_attribution=True,
+        )
+
+        self.assertTrue(
+            any(issue.code == "missing_source_attribution" for issue in issues)
+        )
+
+    def test_placeholder_source_attribution_fails_when_markers_are_expected(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n## Source Attribution\n\n"
+            "- **Article Title**: Source name - URL\n",
+            require_source_attribution=True,
+            source_attribution_markers=[
+                "Example Source",
+                "https://example.test/report",
+            ],
+        )
+
+        self.assertTrue(
+            any(issue.code == "missing_source_attribution" for issue in issues)
+        )
+
+    def test_no_sources_list_item_fails_when_markers_are_expected(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n## Source Attribution\n\n- No sources were provided.\n",
+            require_source_attribution=True,
+            source_attribution_markers=[
+                "Example Source",
+                "https://example.test/report",
+            ],
+        )
+
+        self.assertTrue(
+            any(issue.code == "missing_source_attribution" for issue in issues)
+        )
+
+    def test_source_attribution_requirement_passes_when_section_exists(self):
+        self.assertEqual(
+            validate_report_content(
+                VALID_REPORT_WITH_SOURCE_ATTRIBUTION,
+                require_source_attribution=True,
+            ),
+            [],
+        )
+
+    def test_source_attribution_requirement_passes_when_marker_matches(self):
+        self.assertEqual(
+            validate_report_content(
+                VALID_REPORT_WITH_SOURCE_ATTRIBUTION,
+                require_source_attribution=True,
+                source_attribution_markers=[
+                    "Example Source",
+                    "https://example.test/report",
+                ],
+            ),
+            [],
+        )
+
+    def test_source_attribution_fails_when_any_expected_group_is_missing(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n## Source Attribution\n\n"
+            "- **First Report**: First Source - https://example.test/first\n",
+            require_source_attribution=True,
+            source_attribution_groups=[
+                ["First Source", "https://example.test/first"],
+                ["Second Source", "https://example.test/second"],
+            ],
+        )
+
+        self.assertTrue(
+            any(issue.code == "missing_source_attribution" for issue in issues)
+        )
+
+    def test_source_attribution_passes_when_each_expected_group_matches(self):
+        self.assertEqual(
+            validate_report_content(
+                VALID_REPORT + "\n## Source Attribution\n\n"
+                "- **First Report**: First Source - https://example.test/first\n"
+                "- **Second Report**: Second Source - https://example.test/second\n",
+                require_source_attribution=True,
+                source_attribution_groups=[
+                    ["First Source", "https://example.test/first"],
+                    ["Second Source", "https://example.test/second"],
+                ],
+            ),
+            [],
+        )
 
     def test_api_error_marker_fails(self):
         issues = validate_report_content(

--- a/tests/test_workflow_guards.py
+++ b/tests/test_workflow_guards.py
@@ -122,6 +122,45 @@ class WorkflowGuardTests(unittest.TestCase):
             self.assertIn("report_validation_errors", result)
             self.assertFalse(output_path.exists())
 
+    def test_missing_required_source_attribution_does_not_write_output_file(self):
+        workflow = import_workflow_with_stubs()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "index.md"
+            state = {
+                "analysis_results": {
+                    "exploitation_report": (
+                        "# Exploitation Report\n\n"
+                        "Recent exploitation activity is concentrated in edge systems.\n\n"
+                        "## Active Exploitation Details\n\n"
+                        "### Example Vulnerability\n"
+                        "- **Description**: Attackers are exploiting a vulnerable service.\n\n"
+                        "## Affected Systems and Products\n\n"
+                        "- **Example Product**: Affected versions are exposed.\n\n"
+                        "## Attack Vectors and Techniques\n\n"
+                        "- **Internet-facing service**: Attackers send crafted requests.\n\n"
+                        "## Threat Actor Activities\n\n"
+                        "- **Unknown actor**: Opportunistic exploitation.\n"
+                    ),
+                    "source_attribution_required": True,
+                    "source_attribution_markers": [
+                        "Example Source",
+                        "https://example.test/report",
+                    ],
+                    "source_attribution_groups": [
+                        ["Example Source", "https://example.test/report"]
+                    ],
+                },
+                "config": {"output_path": str(output_path)},
+                "status": "started",
+            }
+
+            result = asyncio.run(workflow.generate_report(state))
+
+            self.assertEqual(result["status"], "failed")
+            self.assertIn("report_validation_errors", result)
+            self.assertFalse(output_path.exists())
+
     def test_skipped_analysis_does_not_write_output_file(self):
         workflow = import_workflow_with_stubs()
 


### PR DESCRIPTION
## Summary
- Require generated exploitation reports to include source attribution when article metadata is available.
- Guard the analysis prompt contract with a deterministic OpenCode stub test.

## Validation
- `uv run python -B -W error -m pytest tests/test_analyze_guards.py -q -p no:cacheprovider`
- `git diff --check`
- `bash scripts/local_validation.sh`