### PR TITLE
Require source attribution contract

### DIFF
--- a/src/core/analyze.py
+++ b/src/core/analyze.py
@@ -103,25 +103,6 @@ def clean_article_text(value: Any, default: str = "") -> str:
     return str(value).strip()
 
 
-def collect_source_attribution_requirements(
-    articles: list[Dict[str, Any]],
-) -> list[list[str]]:
-    """Build per-article markers that must appear in source attribution."""
-    requirements: list[list[str]] = []
-    for article in articles:
-        title = clean_article_text(article.get("title"), "Untitled article")
-        source = clean_article_text(article.get("source"))
-        link = clean_article_text(article.get("link"))
-        if link:
-            requirements.append([link])
-        elif source:
-            markers = [source]
-            if title:
-                markers.append(title)
-            requirements.append(markers)
-    return requirements
-
-
 def collect_source_attribution_entries(articles: list[Dict[str, Any]]) -> list[str]:
     entries: list[str] = []
     for article in articles:
@@ -256,7 +237,7 @@ Focus specifically on:
 
 Here are the articles:
 
-{''.join(all_article_summaries)}
+{"".join(all_article_summaries)}
 
 Generate a well-formatted exploitation report following the structure above. Be comprehensive but only include CVE IDs when they are explicitly mentioned in the articles.
 """
@@ -276,9 +257,6 @@ Generate a well-formatted exploitation report following the structure above. Be 
         )
 
         source_attribution_entries = collect_source_attribution_entries(articles)
-        source_attribution_requirements = collect_source_attribution_requirements(
-            articles
-        )
         return {
             "exploitation_report": exploitation_report,
             "date": datetime.now().strftime("%Y-%m-%d"),
@@ -286,7 +264,6 @@ Generate a well-formatted exploitation report following the structure above. Be 
             "cves_identified": list(all_cves),
             "source_attribution_required": bool(source_attribution_entries),
             "source_attribution_entries": source_attribution_entries,
-            "source_attribution_requirements": source_attribution_requirements,
         }
     except OpenCodeUnavailable as e:
         logger.warning(f"Skipping exploitation analysis: {e}")

--- a/src/core/analyze.py
+++ b/src/core/analyze.py
@@ -122,6 +122,24 @@ def collect_source_attribution_requirements(
     return requirements
 
 
+def collect_source_attribution_entries(articles: list[Dict[str, Any]]) -> list[str]:
+    entries: list[str] = []
+    for article in articles:
+        title = clean_article_text(article.get("title"), "Untitled article")
+        title = title or "Untitled article"
+        source = clean_article_text(article.get("source"))
+        link = clean_article_text(article.get("link"))
+
+        if link and source:
+            entries.append(f"- **{title}**: {source} - {link}")
+        elif link:
+            entries.append(f"- **{title}**: {link}")
+        elif source:
+            entries.append(f"- **{title}**: {source}")
+
+    return entries
+
+
 async def analyze_exploitation(
     articles: List[Dict[str, Any]], config: Dict[str, Any]
 ) -> Dict[str, Any]:
@@ -257,6 +275,7 @@ Generate a well-formatted exploitation report following the structure above. Be 
             title="SentryInsight exploitation report",
         )
 
+        source_attribution_entries = collect_source_attribution_entries(articles)
         source_attribution_requirements = collect_source_attribution_requirements(
             articles
         )
@@ -265,7 +284,8 @@ Generate a well-formatted exploitation report following the structure above. Be 
             "date": datetime.now().strftime("%Y-%m-%d"),
             "analyzed_article_count": len(articles),
             "cves_identified": list(all_cves),
-            "source_attribution_required": bool(source_attribution_requirements),
+            "source_attribution_required": bool(source_attribution_entries),
+            "source_attribution_entries": source_attribution_entries,
             "source_attribution_requirements": source_attribution_requirements,
         }
     except OpenCodeUnavailable as e:

--- a/src/core/analyze.py
+++ b/src/core/analyze.py
@@ -7,6 +7,10 @@ import tiktoken
 
 from .model_config import resolve_model, validate_model
 from .opencode_client import OpenCodeClient, OpenCodeUnavailable, parse_model_selection
+from .source_attribution import (
+    clean_article_source,
+    collect_source_attribution_entries,
+)
 
 # Configure logging
 logging.basicConfig(
@@ -77,7 +81,7 @@ def format_article_summary(article: Dict[str, Any]) -> str:
         return str(value).strip()
 
     title = clean_text(article.get("title"), "Untitled article") or "Untitled article"
-    source = clean_text(article.get("source"))
+    source = clean_article_source(article.get("source"))
     link = clean_text(article.get("link"))
     content = clean_text(
         article.get("content", article.get("summary")),
@@ -95,30 +99,6 @@ def format_article_summary(article: Dict[str, Any]) -> str:
         heading = f"{heading} ({'; '.join(metadata)})"
 
     return f"{heading}\n\n{content[:500]}...\n\n"
-
-
-def clean_article_text(value: Any, default: str = "") -> str:
-    if value is None:
-        return default
-    return str(value).strip()
-
-
-def collect_source_attribution_entries(articles: list[Dict[str, Any]]) -> list[str]:
-    entries: list[str] = []
-    for article in articles:
-        title = clean_article_text(article.get("title"), "Untitled article")
-        title = title or "Untitled article"
-        source = clean_article_text(article.get("source"))
-        link = clean_article_text(article.get("link"))
-
-        if link and source:
-            entries.append(f"- **{title}**: {source} - {link}")
-        elif link:
-            entries.append(f"- **{title}**: {link}")
-        elif source:
-            entries.append(f"- **{title}**: {source}")
-
-    return entries
 
 
 async def analyze_exploitation(

--- a/src/core/analyze.py
+++ b/src/core/analyze.py
@@ -97,6 +97,31 @@ def format_article_summary(article: Dict[str, Any]) -> str:
     return f"{heading}\n\n{content[:500]}...\n\n"
 
 
+def clean_article_text(value: Any, default: str = "") -> str:
+    if value is None:
+        return default
+    return str(value).strip()
+
+
+def collect_source_attribution_requirements(
+    articles: list[Dict[str, Any]],
+) -> list[list[str]]:
+    """Build per-article markers that must appear in source attribution."""
+    requirements: list[list[str]] = []
+    for article in articles:
+        title = clean_article_text(article.get("title"), "Untitled article")
+        source = clean_article_text(article.get("source"))
+        link = clean_article_text(article.get("link"))
+        if link:
+            requirements.append([link])
+        elif source:
+            markers = [source]
+            if title:
+                markers.append(title)
+            requirements.append(markers)
+    return requirements
+
+
 async def analyze_exploitation(
     articles: List[Dict[str, Any]], config: Dict[str, Any]
 ) -> Dict[str, Any]:
@@ -188,6 +213,13 @@ Generate a report following this EXACT structure with professional markdown form
 - **Campaign**: Operation descriptions and impacts
 ]
 
+## Source Attribution
+
+[List the source articles used for this report:
+- **Article Title**: Source name - URL
+Only use source names and URLs provided in the article metadata. Do not invent
+or infer sources.]
+
 Formatting requirements:
 - Use proper markdown with **bold** for emphasis
 - Create clear bullet points with good spacing
@@ -195,6 +227,7 @@ Formatting requirements:
 - Write professional, well-structured content
 - Only mention CVE IDs when they are actually provided in the source articles
 - Do NOT mention missing or unavailable CVE information
+- Include the Source Attribution section when article source metadata or URLs are available
 
 Focus specifically on:
 - Zero-day vulnerabilities being actively exploited
@@ -224,11 +257,16 @@ Generate a well-formatted exploitation report following the structure above. Be 
             title="SentryInsight exploitation report",
         )
 
+        source_attribution_requirements = collect_source_attribution_requirements(
+            articles
+        )
         return {
             "exploitation_report": exploitation_report,
             "date": datetime.now().strftime("%Y-%m-%d"),
             "analyzed_article_count": len(articles),
             "cves_identified": list(all_cves),
+            "source_attribution_required": bool(source_attribution_requirements),
+            "source_attribution_requirements": source_attribution_requirements,
         }
     except OpenCodeUnavailable as e:
         logger.warning(f"Skipping exploitation analysis: {e}")

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -19,6 +19,7 @@ SOURCE_ATTRIBUTION_SECTION_PATTERN = re.compile(
     re.MULTILINE,
 )
 SOURCE_ATTRIBUTION_ENTRY_PATTERN = re.compile(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)")
+SOURCE_ATTRIBUTION_URL_PATTERN = re.compile(r"https?://[^\s<>()\[\]\"']+")
 
 ERROR_MARKERS = (
     "# Error",
@@ -605,6 +606,38 @@ def get_source_attribution_entries(markdown: str) -> list[str]:
     return entries
 
 
+def normalize_source_url(value: str) -> str:
+    return html.unescape(value.strip()).rstrip(".,;:")
+
+
+def source_attribution_entry_urls(entry: str) -> set[str]:
+    return {
+        normalize_source_url(match.group(0)).casefold()
+        for match in SOURCE_ATTRIBUTION_URL_PATTERN.finditer(entry)
+    }
+
+
+def source_attribution_requirement_matches(
+    entry: str, marker_group: Iterable[str]
+) -> bool:
+    entry_urls = source_attribution_entry_urls(entry)
+    for marker in marker_group:
+        normalized_marker = marker.strip()
+        if not normalized_marker:
+            continue
+
+        normalized_marker = html.unescape(normalized_marker)
+        if normalized_marker.casefold().startswith(("http://", "https://")):
+            if normalize_source_url(normalized_marker).casefold() not in entry_urls:
+                return False
+            continue
+
+        if normalized_marker.casefold() not in entry:
+            return False
+
+    return True
+
+
 def source_attribution_requirements_met(
     markdown: str, source_attribution_requirements: Iterable[Iterable[str]]
 ) -> bool:
@@ -618,7 +651,7 @@ def source_attribution_requirements_met(
         return False
 
     return all(
-        any(all(marker in entry for marker in group) for entry in entries)
+        any(source_attribution_requirement_matches(entry, group) for entry in entries)
         for group in requirements
     )
 

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -18,6 +18,7 @@ SOURCE_ATTRIBUTION_SECTION_PATTERN = re.compile(
     rf"^{re.escape(SOURCE_ATTRIBUTION_SECTION)}\s*$",
     re.MULTILINE,
 )
+SOURCE_ATTRIBUTION_ENTRY_PATTERN = re.compile(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)")
 
 ERROR_MARKERS = (
     "# Error",
@@ -572,12 +573,37 @@ def get_source_attribution_section_body(markdown: str) -> str:
     )
 
 
+def get_source_attribution_entries(markdown: str) -> list[str]:
+    section_body = strip_markdown_code(get_source_attribution_section_body(markdown))
+    entries: list[str] = []
+    current_entry: list[str] = []
+
+    for line in section_body.splitlines():
+        stripped_line = line.strip()
+        if not stripped_line:
+            continue
+
+        if SOURCE_ATTRIBUTION_ENTRY_PATTERN.match(line):
+            if current_entry:
+                entries.append(" ".join(current_entry).casefold())
+            current_entry = [stripped_line]
+            continue
+
+        if current_entry:
+            current_entry.append(stripped_line)
+        else:
+            entries.append(stripped_line.casefold())
+
+    if current_entry:
+        entries.append(" ".join(current_entry).casefold())
+
+    return entries
+
+
 def source_attribution_requirements_met(
     markdown: str, source_attribution_requirements: Iterable[Iterable[str]]
 ) -> bool:
-    section_body = strip_markdown_code(
-        get_source_attribution_section_body(markdown)
-    ).casefold()
+    entries = get_source_attribution_entries(markdown)
     requirements = [
         [marker.strip().casefold() for marker in group if marker and marker.strip()]
         for group in source_attribution_requirements
@@ -587,7 +613,8 @@ def source_attribution_requirements_met(
         return False
 
     return all(
-        all(marker in section_body for marker in group) for group in requirements
+        any(all(marker in entry for marker in group) for entry in entries)
+        for group in requirements
     )
 
 

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -23,8 +23,9 @@ URL_CONTINUATION_CHARS = frozenset(
     "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     "abcdefghijklmnopqrstuvwxyz"
     "0123456789"
-    "-._~:/?#[]@!$&'()*+,;=%"
+    "-_~:/?#[]@!$&'*+=%"
 )
+URL_TERMINATOR_CHARS = frozenset(").,;:")
 
 ERROR_MARKERS = (
     "# Error",
@@ -611,10 +612,18 @@ def get_source_attribution_entries(markdown: str) -> list[str]:
     return entries
 
 
-def is_url_delimited(value: str, end_index: int) -> bool:
+def is_url_delimited(value: str, matched_url: str, end_index: int) -> bool:
     if end_index >= len(value):
         return True
-    return value[end_index] not in URL_CONTINUATION_CHARS
+    next_char = value[end_index]
+    if next_char in URL_CONTINUATION_CHARS:
+        return False
+    if next_char in URL_TERMINATOR_CHARS:
+        if matched_url.endswith(next_char):
+            return False
+        next_index = end_index + 1
+        return next_index >= len(value) or value[next_index].isspace()
+    return True
 
 
 def entry_contains_exact_url(entry: str, url: str) -> bool:
@@ -630,7 +639,7 @@ def entry_contains_exact_url(entry: str, url: str) -> bool:
             return False
 
         match_end = match_start + len(normalized_url)
-        if is_url_delimited(normalized_entry, match_end):
+        if is_url_delimited(normalized_entry, normalized_url, match_end):
             return True
 
         search_start = match_start + 1

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -13,6 +13,11 @@ REQUIRED_SECTIONS = (
     "## Attack Vectors and Techniques",
     "## Threat Actor Activities",
 )
+SOURCE_ATTRIBUTION_SECTION = "## Source Attribution"
+SOURCE_ATTRIBUTION_SECTION_PATTERN = re.compile(
+    rf"^{re.escape(SOURCE_ATTRIBUTION_SECTION)}\s*$",
+    re.MULTILINE,
+)
 
 ERROR_MARKERS = (
     "# Error",
@@ -553,7 +558,44 @@ def contains_active_markdown_link(markdown: str) -> bool:
     return False
 
 
-def validate_report_content(markdown: str) -> List[ReportValidationIssue]:
+def get_source_attribution_section_body(markdown: str) -> str:
+    section_match = SOURCE_ATTRIBUTION_SECTION_PATTERN.search(markdown)
+    if not section_match:
+        return ""
+
+    section_body_start = section_match.end()
+    next_section = re.search(r"^##\s+", markdown[section_body_start:], re.MULTILINE)
+    return (
+        markdown[section_body_start : section_body_start + next_section.start()]
+        if next_section
+        else markdown[section_body_start:]
+    )
+
+
+def source_attribution_requirements_met(
+    markdown: str, source_attribution_requirements: Iterable[Iterable[str]]
+) -> bool:
+    section_body = strip_markdown_code(
+        get_source_attribution_section_body(markdown)
+    ).casefold()
+    requirements = [
+        [marker.strip().casefold() for marker in group if marker and marker.strip()]
+        for group in source_attribution_requirements
+    ]
+    requirements = [group for group in requirements if group]
+    if not requirements:
+        return False
+
+    return all(
+        all(marker in section_body for marker in group) for group in requirements
+    )
+
+
+def validate_report_content(
+    markdown: str,
+    require_source_attribution: bool = False,
+    source_attribution_requirements: Iterable[Iterable[str]] | None = None,
+) -> List[ReportValidationIssue]:
     """Return validation issues that should block publishing."""
     issues: List[ReportValidationIssue] = []
     content = markdown.strip()
@@ -623,6 +665,19 @@ def validate_report_content(markdown: str) -> List[ReportValidationIssue]:
                     message=f"Report is missing required section: {section}",
                 )
             )
+
+    if require_source_attribution and not source_attribution_requirements_met(
+        content, source_attribution_requirements or []
+    ):
+        issues.append(
+            ReportValidationIssue(
+                code="missing_source_attribution",
+                message=(
+                    "Report is missing required source attribution entries in section: "
+                    f"{SOURCE_ATTRIBUTION_SECTION}"
+                ),
+            )
+        )
 
     return issues
 

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -579,27 +579,36 @@ def get_source_attribution_section_body(markdown: str) -> str:
 
 
 def remove_source_attribution_section(markdown: str) -> str:
-    lines = markdown.splitlines()
+    lines = markdown.splitlines(keepends=True)
     retained_lines: list[str] = []
-    in_fenced_code = False
+    fence: str | None = None
     skipping_section = False
 
     for line in lines:
-        stripped_line = line.lstrip()
-        if stripped_line.startswith("```"):
-            in_fenced_code = not in_fenced_code
+        if fence is not None:
+            if is_fence_closer(line, fence):
+                fence = None
+            if not skipping_section:
+                retained_lines.append(line)
+            continue
 
-        if not in_fenced_code and SOURCE_ATTRIBUTION_SECTION_PATTERN.match(line):
+        if fence_opener := parse_fence_opener(line):
+            fence = fence_opener
+            if not skipping_section:
+                retained_lines.append(line)
+            continue
+
+        if SOURCE_ATTRIBUTION_SECTION_PATTERN.match(line):
             skipping_section = True
             continue
 
-        if skipping_section and not in_fenced_code and re.match(r"^##\s+", line):
+        if skipping_section and re.match(r"^##\s+", line):
             skipping_section = False
 
         if not skipping_section:
             retained_lines.append(line)
 
-    return "\n".join(retained_lines).rstrip()
+    return "".join(retained_lines).rstrip()
 
 
 def render_source_attribution_section(source_attribution_entries: Iterable[str]) -> str:
@@ -664,7 +673,6 @@ def exact_source_attribution_entries_present(
 def validate_report_content(
     markdown: str,
     require_source_attribution: bool = False,
-    source_attribution_requirements: Iterable[Iterable[str]] | None = None,
     source_attribution_entries: Iterable[str] | None = None,
 ) -> List[ReportValidationIssue]:
     """Return validation issues that should block publishing."""

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -19,13 +19,6 @@ SOURCE_ATTRIBUTION_SECTION_PATTERN = re.compile(
     re.MULTILINE,
 )
 SOURCE_ATTRIBUTION_ENTRY_PATTERN = re.compile(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)")
-URL_CONTINUATION_CHARS = frozenset(
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    "abcdefghijklmnopqrstuvwxyz"
-    "0123456789"
-    "-_~:/?#[]@!$&'*+=%"
-)
-URL_TERMINATOR_CHARS = frozenset(").,;:")
 
 ERROR_MARKERS = (
     "# Error",
@@ -585,6 +578,37 @@ def get_source_attribution_section_body(markdown: str) -> str:
     )
 
 
+def remove_source_attribution_section(markdown: str) -> str:
+    section_match = SOURCE_ATTRIBUTION_SECTION_PATTERN.search(markdown)
+    if not section_match:
+        return markdown
+
+    section_start = section_match.start()
+    next_section = re.search(r"^##\s+", markdown[section_match.end() :], re.MULTILINE)
+    section_end = (
+        section_match.end() + next_section.start() if next_section else len(markdown)
+    )
+    return markdown[:section_start].rstrip() + "\n\n" + markdown[section_end:].lstrip()
+
+
+def render_source_attribution_section(source_attribution_entries: Iterable[str]) -> str:
+    entries = [entry.strip() for entry in source_attribution_entries if entry.strip()]
+    if not entries:
+        return ""
+    return f"{SOURCE_ATTRIBUTION_SECTION}\n\n" + "\n".join(entries) + "\n"
+
+
+def ensure_source_attribution_section(
+    markdown: str, source_attribution_entries: Iterable[str]
+) -> str:
+    section = render_source_attribution_section(source_attribution_entries)
+    if not section:
+        return markdown
+
+    report_without_source_attribution = remove_source_attribution_section(markdown)
+    return f"{report_without_source_attribution.rstrip()}\n\n{section}"
+
+
 def get_source_attribution_entries(markdown: str) -> list[str]:
     section_body = get_source_attribution_section_body(markdown)
     entries: list[str] = []
@@ -597,96 +621,40 @@ def get_source_attribution_entries(markdown: str) -> list[str]:
 
         if SOURCE_ATTRIBUTION_ENTRY_PATTERN.match(line):
             if current_entry:
-                entries.append(" ".join(current_entry).casefold())
+                entries.append(" ".join(current_entry))
             current_entry = [stripped_line]
             continue
 
         if current_entry:
             current_entry.append(stripped_line)
         else:
-            entries.append(stripped_line.casefold())
+            entries.append(stripped_line)
 
     if current_entry:
-        entries.append(" ".join(current_entry).casefold())
+        entries.append(" ".join(current_entry))
 
     return entries
 
 
-def is_url_delimited(value: str, matched_url: str, end_index: int) -> bool:
-    if end_index >= len(value):
-        return True
-    next_char = value[end_index]
-    if next_char in URL_CONTINUATION_CHARS:
-        return False
-    if next_char in URL_TERMINATOR_CHARS:
-        if matched_url.endswith(next_char):
-            return False
-        next_index = end_index + 1
-        return next_index >= len(value) or value[next_index].isspace()
-    return True
-
-
-def entry_contains_exact_url(entry: str, url: str) -> bool:
-    normalized_entry = html.unescape(entry).casefold()
-    normalized_url = html.unescape(url.strip()).casefold()
-    if not normalized_url:
-        return False
-
-    search_start = 0
-    while True:
-        match_start = normalized_entry.find(normalized_url, search_start)
-        if match_start == -1:
-            return False
-
-        match_end = match_start + len(normalized_url)
-        if is_url_delimited(normalized_entry, normalized_url, match_end):
-            return True
-
-        search_start = match_start + 1
-
-
-def source_attribution_requirement_matches(
-    entry: str, marker_group: Iterable[str]
+def exact_source_attribution_entries_present(
+    markdown: str, source_attribution_entries: Iterable[str]
 ) -> bool:
-    for marker in marker_group:
-        normalized_marker = marker.strip()
-        if not normalized_marker:
-            continue
-
-        normalized_marker = html.unescape(normalized_marker)
-        if normalized_marker.casefold().startswith(("http://", "https://")):
-            if not entry_contains_exact_url(entry, normalized_marker):
-                return False
-            continue
-
-        if normalized_marker.casefold() not in entry:
-            return False
-
-    return True
-
-
-def source_attribution_requirements_met(
-    markdown: str, source_attribution_requirements: Iterable[Iterable[str]]
-) -> bool:
-    entries = get_source_attribution_entries(markdown)
-    requirements = [
-        [marker.strip().casefold() for marker in group if marker and marker.strip()]
-        for group in source_attribution_requirements
-    ]
-    requirements = [group for group in requirements if group]
-    if not requirements:
-        return False
-
-    return all(
-        any(source_attribution_requirement_matches(entry, group) for entry in entries)
-        for group in requirements
-    )
+    expected_entries = {
+        html.unescape(entry.strip())
+        for entry in source_attribution_entries
+        if entry.strip()
+    }
+    actual_entries = {
+        html.unescape(entry) for entry in get_source_attribution_entries(markdown)
+    }
+    return bool(expected_entries) and expected_entries.issubset(actual_entries)
 
 
 def validate_report_content(
     markdown: str,
     require_source_attribution: bool = False,
     source_attribution_requirements: Iterable[Iterable[str]] | None = None,
+    source_attribution_entries: Iterable[str] | None = None,
 ) -> List[ReportValidationIssue]:
     """Return validation issues that should block publishing."""
     issues: List[ReportValidationIssue] = []
@@ -758,9 +726,12 @@ def validate_report_content(
                 )
             )
 
-    if require_source_attribution and not source_attribution_requirements_met(
-        content, source_attribution_requirements or []
-    ):
+    source_attribution_is_valid = (
+        exact_source_attribution_entries_present(content, source_attribution_entries)
+        if source_attribution_entries is not None
+        else False
+    )
+    if require_source_attribution and not source_attribution_is_valid:
         issues.append(
             ReportValidationIssue(
                 code="missing_source_attribution",

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -560,21 +560,26 @@ def contains_active_markdown_link(markdown: str) -> bool:
 
 
 def get_source_attribution_section_body(markdown: str) -> str:
-    section_match = SOURCE_ATTRIBUTION_SECTION_PATTERN.search(markdown)
+    searchable_markdown = strip_markdown_code(markdown)
+    section_match = SOURCE_ATTRIBUTION_SECTION_PATTERN.search(searchable_markdown)
     if not section_match:
         return ""
 
     section_body_start = section_match.end()
-    next_section = re.search(r"^##\s+", markdown[section_body_start:], re.MULTILINE)
+    next_section = re.search(
+        r"^##\s+", searchable_markdown[section_body_start:], re.MULTILINE
+    )
     return (
-        markdown[section_body_start : section_body_start + next_section.start()]
+        searchable_markdown[
+            section_body_start : section_body_start + next_section.start()
+        ]
         if next_section
-        else markdown[section_body_start:]
+        else searchable_markdown[section_body_start:]
     )
 
 
 def get_source_attribution_entries(markdown: str) -> list[str]:
-    section_body = strip_markdown_code(get_source_attribution_section_body(markdown))
+    section_body = get_source_attribution_section_body(markdown)
     entries: list[str] = []
     current_entry: list[str] = []
 

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -579,16 +579,27 @@ def get_source_attribution_section_body(markdown: str) -> str:
 
 
 def remove_source_attribution_section(markdown: str) -> str:
-    section_match = SOURCE_ATTRIBUTION_SECTION_PATTERN.search(markdown)
-    if not section_match:
-        return markdown
+    lines = markdown.splitlines()
+    retained_lines: list[str] = []
+    in_fenced_code = False
+    skipping_section = False
 
-    section_start = section_match.start()
-    next_section = re.search(r"^##\s+", markdown[section_match.end() :], re.MULTILINE)
-    section_end = (
-        section_match.end() + next_section.start() if next_section else len(markdown)
-    )
-    return markdown[:section_start].rstrip() + "\n\n" + markdown[section_end:].lstrip()
+    for line in lines:
+        stripped_line = line.lstrip()
+        if stripped_line.startswith("```"):
+            in_fenced_code = not in_fenced_code
+
+        if not in_fenced_code and SOURCE_ATTRIBUTION_SECTION_PATTERN.match(line):
+            skipping_section = True
+            continue
+
+        if skipping_section and not in_fenced_code and re.match(r"^##\s+", line):
+            skipping_section = False
+
+        if not skipping_section:
+            retained_lines.append(line)
+
+    return "\n".join(retained_lines).rstrip()
 
 
 def render_source_attribution_section(source_attribution_entries: Iterable[str]) -> str:

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -19,7 +19,12 @@ SOURCE_ATTRIBUTION_SECTION_PATTERN = re.compile(
     re.MULTILINE,
 )
 SOURCE_ATTRIBUTION_ENTRY_PATTERN = re.compile(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)")
-SOURCE_ATTRIBUTION_URL_PATTERN = re.compile(r"https?://[^\s<>()\[\]\"']+")
+URL_CONTINUATION_CHARS = frozenset(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "abcdefghijklmnopqrstuvwxyz"
+    "0123456789"
+    "-._~:/?#[]@!$&'()*+,;=%"
+)
 
 ERROR_MARKERS = (
     "# Error",
@@ -606,21 +611,34 @@ def get_source_attribution_entries(markdown: str) -> list[str]:
     return entries
 
 
-def normalize_source_url(value: str) -> str:
-    return html.unescape(value.strip()).rstrip(".,;:")
+def is_url_delimited(value: str, end_index: int) -> bool:
+    if end_index >= len(value):
+        return True
+    return value[end_index] not in URL_CONTINUATION_CHARS
 
 
-def source_attribution_entry_urls(entry: str) -> set[str]:
-    return {
-        normalize_source_url(match.group(0)).casefold()
-        for match in SOURCE_ATTRIBUTION_URL_PATTERN.finditer(entry)
-    }
+def entry_contains_exact_url(entry: str, url: str) -> bool:
+    normalized_entry = html.unescape(entry).casefold()
+    normalized_url = html.unescape(url.strip()).casefold()
+    if not normalized_url:
+        return False
+
+    search_start = 0
+    while True:
+        match_start = normalized_entry.find(normalized_url, search_start)
+        if match_start == -1:
+            return False
+
+        match_end = match_start + len(normalized_url)
+        if is_url_delimited(normalized_entry, match_end):
+            return True
+
+        search_start = match_start + 1
 
 
 def source_attribution_requirement_matches(
     entry: str, marker_group: Iterable[str]
 ) -> bool:
-    entry_urls = source_attribution_entry_urls(entry)
     for marker in marker_group:
         normalized_marker = marker.strip()
         if not normalized_marker:
@@ -628,7 +646,7 @@ def source_attribution_requirement_matches(
 
         normalized_marker = html.unescape(normalized_marker)
         if normalized_marker.casefold().startswith(("http://", "https://")):
-            if normalize_source_url(normalized_marker).casefold() not in entry_urls:
+            if not entry_contains_exact_url(entry, normalized_marker):
                 return False
             continue
 

--- a/src/core/source_attribution.py
+++ b/src/core/source_attribution.py
@@ -1,0 +1,36 @@
+"""Source attribution helpers for generated reports."""
+
+from typing import Any, Dict
+
+UNKNOWN_SOURCE_SENTINELS = {"unknown source"}
+
+
+def clean_article_text(value: Any, default: str = "") -> str:
+    if value is None:
+        return default
+    return str(value).strip()
+
+
+def clean_article_source(value: Any) -> str:
+    source = clean_article_text(value)
+    if source.casefold() in UNKNOWN_SOURCE_SENTINELS:
+        return ""
+    return source
+
+
+def collect_source_attribution_entries(articles: list[Dict[str, Any]]) -> list[str]:
+    entries: list[str] = []
+    for article in articles:
+        title = clean_article_text(article.get("title"), "Untitled article")
+        title = title or "Untitled article"
+        source = clean_article_source(article.get("source"))
+        link = clean_article_text(article.get("link"))
+
+        if link and source:
+            entries.append(f"- **{title}**: {source} - {link}")
+        elif link:
+            entries.append(f"- **{title}**: {link}")
+        elif source:
+            entries.append(f"- **{title}**: {source}")
+
+    return entries

--- a/src/core/workflow.py
+++ b/src/core/workflow.py
@@ -170,9 +170,6 @@ async def generate_report(
         require_source_attribution=bool(
             analysis_results.get("source_attribution_required")
         ),
-        source_attribution_requirements=analysis_results.get(
-            "source_attribution_requirements"
-        ),
         source_attribution_entries=analysis_results.get("source_attribution_entries"),
     )
     if validation_issues:

--- a/src/core/workflow.py
+++ b/src/core/workflow.py
@@ -161,7 +161,15 @@ async def generate_report(
     # Since the exploitation_report already contains the full formatted report,
     # we should use it directly instead of the template
     report = exploitation_report
-    validation_issues = validate_report_content(report)
+    validation_issues = validate_report_content(
+        report,
+        require_source_attribution=bool(
+            analysis_results.get("source_attribution_required")
+        ),
+        source_attribution_requirements=analysis_results.get(
+            "source_attribution_requirements"
+        ),
+    )
     if validation_issues:
         logger.error(
             "Report validation failed:\n%s",

--- a/src/core/workflow.py
+++ b/src/core/workflow.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from ..services.fetch import SentryDigestFeedClient
 from .analyze import filter_exploitation_articles, analyze_exploitation
 from .report_validation import (
+    ensure_source_attribution_section,
     format_report_validation_issues,
     validate_report_content,
 )
@@ -160,7 +161,10 @@ async def generate_report(
 
     # Since the exploitation_report already contains the full formatted report,
     # we should use it directly instead of the template
-    report = exploitation_report
+    report = ensure_source_attribution_section(
+        exploitation_report,
+        analysis_results.get("source_attribution_entries") or [],
+    )
     validation_issues = validate_report_content(
         report,
         require_source_attribution=bool(
@@ -169,6 +173,7 @@ async def generate_report(
         source_attribution_requirements=analysis_results.get(
             "source_attribution_requirements"
         ),
+        source_attribution_entries=analysis_results.get("source_attribution_entries"),
     )
     if validation_issues:
         logger.error(

--- a/src/services/publish.py
+++ b/src/services/publish.py
@@ -45,7 +45,15 @@ async def publish_to_github_pages(
             "exploitation_report", "No exploitation report available."
         )
         report_date = analysis_results.get("date", datetime.now().strftime("%Y-%m-%d"))
-        validation_issues = validate_report_content(exploitation_report)
+        validation_issues = validate_report_content(
+            exploitation_report,
+            require_source_attribution=bool(
+                analysis_results.get("source_attribution_required")
+            ),
+            source_attribution_requirements=analysis_results.get(
+                "source_attribution_requirements"
+            ),
+        )
         if validation_issues:
             logger.error(
                 "Refusing to publish invalid report:\n%s",

--- a/src/services/publish.py
+++ b/src/services/publish.py
@@ -55,9 +55,6 @@ async def publish_to_github_pages(
             require_source_attribution=bool(
                 analysis_results.get("source_attribution_required")
             ),
-            source_attribution_requirements=analysis_results.get(
-                "source_attribution_requirements"
-            ),
             source_attribution_entries=analysis_results.get(
                 "source_attribution_entries"
             ),

--- a/src/services/publish.py
+++ b/src/services/publish.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Dict, Any
 
 from src.core.report_validation import (
+    ensure_source_attribution_section,
     format_report_validation_issues,
     validate_report_content,
 )
@@ -44,6 +45,10 @@ async def publish_to_github_pages(
         exploitation_report = analysis_results.get(
             "exploitation_report", "No exploitation report available."
         )
+        exploitation_report = ensure_source_attribution_section(
+            exploitation_report,
+            analysis_results.get("source_attribution_entries") or [],
+        )
         report_date = analysis_results.get("date", datetime.now().strftime("%Y-%m-%d"))
         validation_issues = validate_report_content(
             exploitation_report,
@@ -52,6 +57,9 @@ async def publish_to_github_pages(
             ),
             source_attribution_requirements=analysis_results.get(
                 "source_attribution_requirements"
+            ),
+            source_attribution_entries=analysis_results.get(
+                "source_attribution_entries"
             ),
         )
         if validation_issues:

--- a/tests/test_analyze_guards.py
+++ b/tests/test_analyze_guards.py
@@ -142,6 +142,92 @@ class AnalyzeGuardTests(unittest.TestCase):
         self.assertNotIn("(Source: )", FakeOpenCodeClient.user_prompt)
         self.assertNotIn("URL: \n", FakeOpenCodeClient.user_prompt)
 
+    def test_prompt_requires_source_attribution_from_article_metadata(self):
+        analyze = import_analyze_with_stubs()
+
+        class FakeOpenCodeClient:
+            def __init__(self, **_kwargs):
+                pass
+
+            async def generate(self, **kwargs):
+                self.__class__.user_prompt = kwargs["user_prompt"]
+                return "# Exploitation Report\n\nGenerated through OpenCode."
+
+        analyze.OpenCodeClient = FakeOpenCodeClient
+
+        with patch.dict(os.environ, {}, clear=True):
+            asyncio.run(
+                analyze.analyze_exploitation(
+                    articles=[
+                        {
+                            "title": "Example exploitation report",
+                            "source": "Example Source",
+                            "link": "https://example.test/report",
+                            "summary": "Summary only",
+                        }
+                    ],
+                    config={
+                        "analysis": {
+                            "model": "openrouter/nvidia/nemotron-3-ultra-550b-a55b:free"
+                        }
+                    },
+                )
+            )
+
+        self.assertIn("## Source Attribution", FakeOpenCodeClient.user_prompt)
+        self.assertIn(
+            "Only use source names and URLs provided",
+            FakeOpenCodeClient.user_prompt,
+        )
+        self.assertIn("Example exploitation report", FakeOpenCodeClient.user_prompt)
+        self.assertIn("Example Source", FakeOpenCodeClient.user_prompt)
+        self.assertIn("https://example.test/report", FakeOpenCodeClient.user_prompt)
+
+    def test_analysis_result_carries_url_first_source_attribution_requirements(self):
+        analyze = import_analyze_with_stubs()
+
+        class FakeOpenCodeClient:
+            def __init__(self, **_kwargs):
+                pass
+
+            async def generate(self, **_kwargs):
+                return "# Exploitation Report\n\nGenerated through OpenCode."
+
+        analyze.OpenCodeClient = FakeOpenCodeClient
+
+        with patch.dict(os.environ, {}, clear=True):
+            result = asyncio.run(
+                analyze.analyze_exploitation(
+                    articles=[
+                        {
+                            "title": "Example exploitation report",
+                            "source": "Example Source",
+                            "link": "https://example.test/report",
+                            "summary": "Summary only",
+                        },
+                        {
+                            "title": "Source-only exploitation report",
+                            "source": "Example Source",
+                            "summary": "Summary only",
+                        },
+                    ],
+                    config={
+                        "analysis": {
+                            "model": "openrouter/nvidia/nemotron-3-ultra-550b-a55b:free"
+                        }
+                    },
+                )
+            )
+
+        self.assertTrue(result["source_attribution_required"])
+        self.assertEqual(
+            result["source_attribution_requirements"],
+            [
+                ["https://example.test/report"],
+                ["Example Source", "Source-only exploitation report"],
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_analyze_guards.py
+++ b/tests/test_analyze_guards.py
@@ -221,6 +221,13 @@ class AnalyzeGuardTests(unittest.TestCase):
 
         self.assertTrue(result["source_attribution_required"])
         self.assertEqual(
+            result["source_attribution_entries"],
+            [
+                "- **Example exploitation report**: Example Source - https://example.test/report",
+                "- **Source-only exploitation report**: Example Source",
+            ],
+        )
+        self.assertEqual(
             result["source_attribution_requirements"],
             [
                 ["https://example.test/report"],

--- a/tests/test_analyze_guards.py
+++ b/tests/test_analyze_guards.py
@@ -183,7 +183,7 @@ class AnalyzeGuardTests(unittest.TestCase):
         self.assertIn("Example Source", FakeOpenCodeClient.user_prompt)
         self.assertIn("https://example.test/report", FakeOpenCodeClient.user_prompt)
 
-    def test_analysis_result_carries_url_first_source_attribution_requirements(self):
+    def test_analysis_result_carries_canonical_source_attribution_entries(self):
         analyze = import_analyze_with_stubs()
 
         class FakeOpenCodeClient:
@@ -227,13 +227,7 @@ class AnalyzeGuardTests(unittest.TestCase):
                 "- **Source-only exploitation report**: Example Source",
             ],
         )
-        self.assertEqual(
-            result["source_attribution_requirements"],
-            [
-                ["https://example.test/report"],
-                ["Example Source", "Source-only exploitation report"],
-            ],
-        )
+        self.assertNotIn("source_attribution_requirements", result)
 
 
 if __name__ == "__main__":

--- a/tests/test_analyze_guards.py
+++ b/tests/test_analyze_guards.py
@@ -15,9 +15,26 @@ def import_analyze_with_stubs():
         encode=lambda value: value.split()
     )
 
+    opencode_client_module = types.ModuleType("src.core.opencode_client")
+
+    class OpenCodeUnavailable(RuntimeError):
+        pass
+
+    class OpenCodeClient:
+        pass
+
+    def parse_model_selection(model_name):
+        provider_id, model_id = model_name.split("/", 1)
+        return types.SimpleNamespace(provider_id=provider_id, model_id=model_id)
+
+    opencode_client_module.OpenCodeClient = OpenCodeClient
+    opencode_client_module.OpenCodeUnavailable = OpenCodeUnavailable
+    opencode_client_module.parse_model_selection = parse_model_selection
+
     with patch.dict(
         sys.modules,
         {
+            "src.core.opencode_client": opencode_client_module,
             "tiktoken": tiktoken_module,
         },
     ):

--- a/tests/test_publish_guards.py
+++ b/tests/test_publish_guards.py
@@ -69,6 +69,27 @@ class PublishGuardTests(unittest.TestCase):
             self.assertTrue((repo_dir / "navigation.md").exists())
             self.assertTrue((repo_dir / "_config.yml").exists())
 
+    def test_missing_required_source_attribution_is_not_written(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_dir = Path(tmpdir) / "docs"
+            result = asyncio.run(
+                publish_to_github_pages(
+                    {
+                        "exploitation_report": VALID_REPORT,
+                        "date": "2026-06-17",
+                        "source_attribution_required": True,
+                        "source_attribution_requirements": [
+                            ["https://example.test/report"]
+                        ],
+                    },
+                    {"enabled": True, "repo_directory": str(repo_dir)},
+                )
+            )
+
+            self.assertFalse(result)
+            self.assertTrue(repo_dir.exists())
+            self.assertFalse((repo_dir / "index.md").exists())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_publish_guards.py
+++ b/tests/test_publish_guards.py
@@ -69,6 +69,34 @@ class PublishGuardTests(unittest.TestCase):
             self.assertTrue((repo_dir / "navigation.md").exists())
             self.assertTrue((repo_dir / "_config.yml").exists())
 
+    def test_source_attribution_entries_are_written_canonically(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_dir = Path(tmpdir) / "docs"
+            result = asyncio.run(
+                publish_to_github_pages(
+                    {
+                        "exploitation_report": (
+                            VALID_REPORT + "\n## Source Attribution\n\n"
+                            "- **Article Title**: Source name - URL\n"
+                        ),
+                        "date": "2026-06-17",
+                        "source_attribution_required": True,
+                        "source_attribution_entries": [
+                            "- **Vendor advisory**: Vendor - https://vendor.test/Fix"
+                        ],
+                    },
+                    {"enabled": True, "repo_directory": str(repo_dir)},
+                )
+            )
+
+            self.assertTrue(result)
+            report = (repo_dir / "index.md").read_text()
+            self.assertIn(
+                "- **Vendor advisory**: Vendor - https://vendor.test/Fix",
+                report,
+            )
+            self.assertNotIn("Article Title", report)
+
     def test_missing_required_source_attribution_is_not_written(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             repo_dir = Path(tmpdir) / "docs"

--- a/tests/test_publish_guards.py
+++ b/tests/test_publish_guards.py
@@ -38,8 +38,7 @@ class PublishGuardTests(unittest.TestCase):
                 publish_to_github_pages(
                     {
                         "exploitation_report": (
-                            "# Error Generating Exploitation Report\n\n"
-                            "Error code: 404"
+                            "# Error Generating Exploitation Report\n\nError code: 404"
                         ),
                         "date": "2026-06-17",
                     },
@@ -106,9 +105,6 @@ class PublishGuardTests(unittest.TestCase):
                         "exploitation_report": VALID_REPORT,
                         "date": "2026-06-17",
                         "source_attribution_required": True,
-                        "source_attribution_requirements": [
-                            ["https://example.test/report"]
-                        ],
                     },
                     {"enabled": True, "repo_directory": str(repo_dir)},
                 )

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -26,10 +26,166 @@ Recent exploitation activity is concentrated in edge systems.
 - **Unknown actor**: Opportunistic exploitation.
 """
 
+VALID_REPORT_WITH_SOURCE_ATTRIBUTION = VALID_REPORT + """
+## Source Attribution
+
+- **Example exploitation report**: Example Source - https://example.test/report
+- **Second exploitation report**: Example Source - https://example.test/second
+- **Source-only exploitation report**: Example Source
+"""
+
 
 class ReportValidationTests(unittest.TestCase):
     def test_valid_report_passes(self):
         self.assertEqual(validate_report_content(VALID_REPORT), [])
+
+    def test_required_source_attribution_without_requirements_fails(self):
+        issues = validate_report_content(VALID_REPORT, require_source_attribution=True)
+
+        self.assertTrue(
+            any(issue.code == "missing_source_attribution" for issue in issues)
+        )
+
+    def test_missing_required_source_attribution_section_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT,
+            require_source_attribution=True,
+            source_attribution_requirements=[["https://example.test/report"]],
+        )
+
+        self.assertTrue(
+            any(issue.code == "missing_source_attribution" for issue in issues)
+        )
+
+    def test_blank_required_source_attribution_section_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n## Source Attribution\n\n",
+            require_source_attribution=True,
+            source_attribution_requirements=[["https://example.test/report"]],
+        )
+
+        self.assertTrue(
+            any(issue.code == "missing_source_attribution" for issue in issues)
+        )
+
+    def test_source_attribution_heading_mention_does_not_satisfy_requirement(self):
+        issues = validate_report_content(
+            VALID_REPORT
+            + "\nThis report should include ## Source Attribution with https://example.test/report.\n",
+            require_source_attribution=True,
+            source_attribution_requirements=[["https://example.test/report"]],
+        )
+
+        self.assertTrue(
+            any(issue.code == "missing_source_attribution" for issue in issues)
+        )
+
+    def test_source_attribution_inside_code_block_does_not_satisfy_requirement(self):
+        issues = validate_report_content(
+            VALID_REPORT + """
+## Source Attribution
+
+```text
+https://example.test/report
+```
+""",
+            require_source_attribution=True,
+            source_attribution_requirements=[["https://example.test/report"]],
+        )
+
+        self.assertTrue(
+            any(issue.code == "missing_source_attribution" for issue in issues)
+        )
+
+    def test_placeholder_source_attribution_entry_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT
+            + "\n## Source Attribution\n\n- **Article Title**: Source name - URL\n",
+            require_source_attribution=True,
+            source_attribution_requirements=[["https://example.test/report"]],
+        )
+
+        self.assertTrue(
+            any(issue.code == "missing_source_attribution" for issue in issues)
+        )
+
+    def test_negative_source_attribution_entry_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT + "\n## Source Attribution\n\n- No sources were provided.\n",
+            require_source_attribution=True,
+            source_attribution_requirements=[["https://example.test/report"]],
+        )
+
+        self.assertTrue(
+            any(issue.code == "missing_source_attribution" for issue in issues)
+        )
+
+    def test_source_name_only_fails_when_url_is_required(self):
+        issues = validate_report_content(
+            VALID_REPORT
+            + "\n## Source Attribution\n\n- **Example exploitation report**: Example Source\n",
+            require_source_attribution=True,
+            source_attribution_requirements=[["https://example.test/report"]],
+        )
+
+        self.assertTrue(
+            any(issue.code == "missing_source_attribution" for issue in issues)
+        )
+
+    def test_repeated_source_name_requires_each_url(self):
+        partial_report = VALID_REPORT + """
+## Source Attribution
+
+- **Example exploitation report**: Example Source - https://example.test/report
+"""
+
+        issues = validate_report_content(
+            partial_report,
+            require_source_attribution=True,
+            source_attribution_requirements=[
+                ["https://example.test/report"],
+                ["https://example.test/second"],
+            ],
+        )
+        self.assertTrue(
+            any(issue.code == "missing_source_attribution" for issue in issues)
+        )
+
+        self.assertEqual(
+            validate_report_content(
+                VALID_REPORT_WITH_SOURCE_ATTRIBUTION,
+                require_source_attribution=True,
+                source_attribution_requirements=[
+                    ["https://example.test/report"],
+                    ["https://example.test/second"],
+                ],
+            ),
+            [],
+        )
+
+    def test_source_only_article_requires_source_and_title(self):
+        issues = validate_report_content(
+            VALID_REPORT
+            + "\n## Source Attribution\n\n- **Different report**: Example Source\n",
+            require_source_attribution=True,
+            source_attribution_requirements=[
+                ["Example Source", "Source-only exploitation report"]
+            ],
+        )
+
+        self.assertTrue(
+            any(issue.code == "missing_source_attribution" for issue in issues)
+        )
+        self.assertEqual(
+            validate_report_content(
+                VALID_REPORT_WITH_SOURCE_ATTRIBUTION,
+                require_source_attribution=True,
+                source_attribution_requirements=[
+                    ["Example Source", "Source-only exploitation report"]
+                ],
+            ),
+            [],
+        )
 
     def test_api_error_marker_fails(self):
         issues = validate_report_content(

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -1,6 +1,9 @@
 import unittest
 
-from src.core.report_validation import validate_report_content
+from src.core.report_validation import (
+    ensure_source_attribution_section,
+    validate_report_content,
+)
 
 VALID_REPORT = """# Exploitation Report
 
@@ -39,6 +42,79 @@ class ReportValidationTests(unittest.TestCase):
     def test_valid_report_passes(self):
         self.assertEqual(validate_report_content(VALID_REPORT), [])
 
+    def test_ensure_source_attribution_section_appends_canonical_entries(self):
+        report = ensure_source_attribution_section(
+            VALID_REPORT,
+            [
+                "- **Example exploitation report**: Example Source - https://example.test/report"
+            ],
+        )
+
+        self.assertIn(
+            "\n## Source Attribution\n\n"
+            "- **Example exploitation report**: Example Source - https://example.test/report\n",
+            report,
+        )
+        self.assertEqual(
+            validate_report_content(
+                report,
+                require_source_attribution=True,
+                source_attribution_entries=[
+                    "- **Example exploitation report**: Example Source - https://example.test/report"
+                ],
+            ),
+            [],
+        )
+
+    def test_ensure_source_attribution_section_replaces_existing_section(self):
+        report = ensure_source_attribution_section(
+            VALID_REPORT
+            + "\n## Source Attribution\n\n- **Article Title**: Source name - URL\n",
+            [
+                "- **Example exploitation report**: Example Source - https://example.test/report"
+            ],
+        )
+
+        self.assertNotIn("Article Title", report)
+        self.assertIn(
+            "- **Example exploitation report**: Example Source - https://example.test/report",
+            report,
+        )
+
+    def test_exact_source_attribution_entries_reject_embedded_url(self):
+        issues = validate_report_content(
+            VALID_REPORT + """
+## Source Attribution
+
+- **Aggregator URL report**: Example Source - https://aggregator.test/?u=https://vendor.test/advisory
+""",
+            require_source_attribution=True,
+            source_attribution_entries=[
+                "- **Vendor advisory**: Vendor - https://vendor.test/advisory"
+            ],
+        )
+
+        self.assertTrue(
+            any(issue.code == "missing_source_attribution" for issue in issues)
+        )
+
+    def test_exact_source_attribution_entries_preserve_url_case(self):
+        issues = validate_report_content(
+            VALID_REPORT + """
+## Source Attribution
+
+- **Vendor advisory**: Vendor - https://vendor.test/Fix
+""",
+            require_source_attribution=True,
+            source_attribution_entries=[
+                "- **Vendor advisory**: Vendor - https://vendor.test/fix"
+            ],
+        )
+
+        self.assertTrue(
+            any(issue.code == "missing_source_attribution" for issue in issues)
+        )
+
     def test_required_source_attribution_without_requirements_fails(self):
         issues = validate_report_content(VALID_REPORT, require_source_attribution=True)
 
@@ -50,7 +126,9 @@ class ReportValidationTests(unittest.TestCase):
         issues = validate_report_content(
             VALID_REPORT,
             require_source_attribution=True,
-            source_attribution_requirements=[["https://example.test/report"]],
+            source_attribution_entries=[
+                "- **Example exploitation report**: Example Source - https://example.test/report"
+            ],
         )
 
         self.assertTrue(
@@ -61,7 +139,9 @@ class ReportValidationTests(unittest.TestCase):
         issues = validate_report_content(
             VALID_REPORT + "\n## Source Attribution\n\n",
             require_source_attribution=True,
-            source_attribution_requirements=[["https://example.test/report"]],
+            source_attribution_entries=[
+                "- **Example exploitation report**: Example Source - https://example.test/report"
+            ],
         )
 
         self.assertTrue(
@@ -73,7 +153,9 @@ class ReportValidationTests(unittest.TestCase):
             VALID_REPORT
             + "\nThis report should include ## Source Attribution with https://example.test/report.\n",
             require_source_attribution=True,
-            source_attribution_requirements=[["https://example.test/report"]],
+            source_attribution_entries=[
+                "- **Example exploitation report**: Example Source - https://example.test/report"
+            ],
         )
 
         self.assertTrue(
@@ -90,7 +172,9 @@ https://example.test/report
 ```
 """,
             require_source_attribution=True,
-            source_attribution_requirements=[["https://example.test/report"]],
+            source_attribution_entries=[
+                "- **Example exploitation report**: Example Source - https://example.test/report"
+            ],
         )
 
         self.assertTrue(
@@ -107,7 +191,9 @@ https://example.test/report
 ```
 """,
             require_source_attribution=True,
-            source_attribution_requirements=[["https://example.test/report"]],
+            source_attribution_entries=[
+                "- **Example exploitation report**: Example Source - https://example.test/report"
+            ],
         )
 
         self.assertTrue(
@@ -119,7 +205,9 @@ https://example.test/report
             VALID_REPORT
             + "\n## Source Attribution\n\n- **Article Title**: Source name - URL\n",
             require_source_attribution=True,
-            source_attribution_requirements=[["https://example.test/report"]],
+            source_attribution_entries=[
+                "- **Example exploitation report**: Example Source - https://example.test/report"
+            ],
         )
 
         self.assertTrue(
@@ -130,7 +218,9 @@ https://example.test/report
         issues = validate_report_content(
             VALID_REPORT + "\n## Source Attribution\n\n- No sources were provided.\n",
             require_source_attribution=True,
-            source_attribution_requirements=[["https://example.test/report"]],
+            source_attribution_entries=[
+                "- **Example exploitation report**: Example Source - https://example.test/report"
+            ],
         )
 
         self.assertTrue(
@@ -142,7 +232,9 @@ https://example.test/report
             VALID_REPORT
             + "\n## Source Attribution\n\n- **Example exploitation report**: Example Source\n",
             require_source_attribution=True,
-            source_attribution_requirements=[["https://example.test/report"]],
+            source_attribution_entries=[
+                "- **Example exploitation report**: Example Source - https://example.test/report"
+            ],
         )
 
         self.assertTrue(
@@ -159,9 +251,9 @@ https://example.test/report
         issues = validate_report_content(
             partial_report,
             require_source_attribution=True,
-            source_attribution_requirements=[
-                ["https://example.test/report"],
-                ["https://example.test/second"],
+            source_attribution_entries=[
+                "- **Example exploitation report**: Example Source - https://example.test/report",
+                "- **Second exploitation report**: Example Source - https://example.test/second",
             ],
         )
         self.assertTrue(
@@ -172,9 +264,9 @@ https://example.test/report
             validate_report_content(
                 VALID_REPORT_WITH_SOURCE_ATTRIBUTION,
                 require_source_attribution=True,
-                source_attribution_requirements=[
-                    ["https://example.test/report"],
-                    ["https://example.test/second"],
+                source_attribution_entries=[
+                    "- **Example exploitation report**: Example Source - https://example.test/report",
+                    "- **Second exploitation report**: Example Source - https://example.test/second",
                 ],
             ),
             [],
@@ -182,14 +274,15 @@ https://example.test/report
 
     def test_url_requirement_requires_exact_url_match(self):
         issues = validate_report_content(
-            VALID_REPORT
-            + """
+            VALID_REPORT + """
 ## Source Attribution
 
 - **Longer URL report**: Example Source - https://example.test/reporting
 """,
             require_source_attribution=True,
-            source_attribution_requirements=[["https://example.test/report"]],
+            source_attribution_entries=[
+                "- **Example exploitation report**: Example Source - https://example.test/report"
+            ],
         )
 
         self.assertTrue(
@@ -198,61 +291,67 @@ https://example.test/report
 
     def test_url_requirement_rejects_extension_prefix_match(self):
         issues = validate_report_content(
-            VALID_REPORT
-            + """
+            VALID_REPORT + """
 ## Source Attribution
 
 - **Extension URL report**: Example Source - https://example.test/report.txt
 """,
             require_source_attribution=True,
-            source_attribution_requirements=[["https://example.test/report"]],
+            source_attribution_entries=[
+                "- **Example exploitation report**: Example Source - https://example.test/report"
+            ],
         )
 
         self.assertTrue(
             any(issue.code == "missing_source_attribution" for issue in issues)
         )
 
-    def test_url_requirement_allows_markdown_link_delimiter(self):
-        self.assertEqual(
-            validate_report_content(
-                VALID_REPORT
-                + """
+    def test_noncanonical_markdown_link_attribution_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT + """
 ## Source Attribution
 
 - **Markdown URL report**: [Example Source](https://example.test/report)
 """,
-                require_source_attribution=True,
-                source_attribution_requirements=[["https://example.test/report"]],
-            ),
-            [],
+            require_source_attribution=True,
+            source_attribution_entries=[
+                "- **Example exploitation report**: Example Source - https://example.test/report"
+            ],
         )
 
-    def test_url_requirement_allows_sentence_punctuation(self):
-        self.assertEqual(
-            validate_report_content(
-                VALID_REPORT
-                + """
+        self.assertTrue(
+            any(issue.code == "missing_source_attribution" for issue in issues)
+        )
+
+    def test_noncanonical_sentence_punctuation_attribution_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT + """
 ## Source Attribution
 
 - **Sentence URL report**: Example Source - https://example.test/report.
 """,
-                require_source_attribution=True,
-                source_attribution_requirements=[["https://example.test/report"]],
-            ),
-            [],
+            require_source_attribution=True,
+            source_attribution_entries=[
+                "- **Example exploitation report**: Example Source - https://example.test/report"
+            ],
+        )
+
+        self.assertTrue(
+            any(issue.code == "missing_source_attribution" for issue in issues)
         )
 
     def test_url_requirement_allows_parentheses_in_url(self):
         self.assertEqual(
             validate_report_content(
-                VALID_REPORT
-                + """
+                VALID_REPORT + """
 ## Source Attribution
 
 - **Parenthesized URL report**: Example Source - https://example.test/report(1)
 """,
                 require_source_attribution=True,
-                source_attribution_requirements=[["https://example.test/report(1)"]],
+                source_attribution_entries=[
+                    "- **Parenthesized URL report**: Example Source - https://example.test/report(1)"
+                ],
             ),
             [],
         )
@@ -262,8 +361,8 @@ https://example.test/report
             VALID_REPORT
             + "\n## Source Attribution\n\n- **Different report**: Example Source\n",
             require_source_attribution=True,
-            source_attribution_requirements=[
-                ["Example Source", "Source-only exploitation report"]
+            source_attribution_entries=[
+                "- **Source-only exploitation report**: Example Source"
             ],
         )
 
@@ -274,8 +373,8 @@ https://example.test/report
             validate_report_content(
                 VALID_REPORT_WITH_SOURCE_ATTRIBUTION,
                 require_source_attribution=True,
-                source_attribution_requirements=[
-                    ["Example Source", "Source-only exploitation report"]
+                source_attribution_entries=[
+                    "- **Source-only exploitation report**: Example Source"
                 ],
             ),
             [],
@@ -283,16 +382,15 @@ https://example.test/report
 
     def test_source_only_markers_must_appear_in_same_attribution_entry(self):
         issues = validate_report_content(
-            VALID_REPORT
-            + """
+            VALID_REPORT + """
 ## Source Attribution
 
 - **Source-only exploitation report**: Different Source
 - **Different report**: Example Source
 """,
             require_source_attribution=True,
-            source_attribution_requirements=[
-                ["Example Source", "Source-only exploitation report"]
+            source_attribution_entries=[
+                "- **Source-only exploitation report**: Example Source"
             ],
         )
 

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -81,6 +81,30 @@ class ReportValidationTests(unittest.TestCase):
             report,
         )
 
+    def test_ensure_source_attribution_section_removes_duplicate_stale_sections(self):
+        report = ensure_source_attribution_section(
+            VALID_REPORT
+            + "\n## Source Attribution\n\n- No sources were provided.\n"
+            + "\n## Source Attribution\n\n- **Article Title**: Source name - URL\n",
+            [
+                "- **Example exploitation report**: Example Source - https://example.test/report"
+            ],
+        )
+
+        self.assertNotIn("No sources were provided", report)
+        self.assertNotIn("Article Title", report)
+        self.assertEqual(report.count("## Source Attribution"), 1)
+        self.assertEqual(
+            validate_report_content(
+                report,
+                require_source_attribution=True,
+                source_attribution_entries=[
+                    "- **Example exploitation report**: Example Source - https://example.test/report"
+                ],
+            ),
+            [],
+        )
+
     def test_exact_source_attribution_entries_reject_embedded_url(self):
         issues = validate_report_content(
             VALID_REPORT + """

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -196,6 +196,21 @@ https://example.test/report
             any(issue.code == "missing_source_attribution" for issue in issues)
         )
 
+    def test_url_requirement_allows_parentheses_in_url(self):
+        self.assertEqual(
+            validate_report_content(
+                VALID_REPORT
+                + """
+## Source Attribution
+
+- **Parenthesized URL report**: Example Source - https://example.test/report(1)
+""",
+                require_source_attribution=True,
+                source_attribution_requirements=[["https://example.test/report(1)"]],
+            ),
+            [],
+        )
+
     def test_source_only_article_requires_source_and_title(self):
         issues = validate_report_content(
             VALID_REPORT

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -105,6 +105,39 @@ class ReportValidationTests(unittest.TestCase):
             [],
         )
 
+    def test_ensure_source_attribution_section_preserves_tilde_fenced_headings(self):
+        report = ensure_source_attribution_section(
+            VALID_REPORT + """
+~~~markdown
+## Source Attribution
+
+- Example text inside a code block
+~~~
+
+## Source Attribution
+
+- No sources were provided.
+""",
+            [
+                "- **Example exploitation report**: Example Source - https://example.test/report"
+            ],
+        )
+
+        self.assertIn("~~~markdown\n## Source Attribution", report)
+        self.assertIn("- Example text inside a code block", report)
+        self.assertNotIn("No sources were provided", report)
+        self.assertEqual(report.count("## Source Attribution"), 2)
+        self.assertEqual(
+            validate_report_content(
+                report,
+                require_source_attribution=True,
+                source_attribution_entries=[
+                    "- **Example exploitation report**: Example Source - https://example.test/report"
+                ],
+            ),
+            [],
+        )
+
     def test_exact_source_attribution_entries_reject_embedded_url(self):
         issues = validate_report_content(
             VALID_REPORT + """

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -196,6 +196,52 @@ https://example.test/report
             any(issue.code == "missing_source_attribution" for issue in issues)
         )
 
+    def test_url_requirement_rejects_extension_prefix_match(self):
+        issues = validate_report_content(
+            VALID_REPORT
+            + """
+## Source Attribution
+
+- **Extension URL report**: Example Source - https://example.test/report.txt
+""",
+            require_source_attribution=True,
+            source_attribution_requirements=[["https://example.test/report"]],
+        )
+
+        self.assertTrue(
+            any(issue.code == "missing_source_attribution" for issue in issues)
+        )
+
+    def test_url_requirement_allows_markdown_link_delimiter(self):
+        self.assertEqual(
+            validate_report_content(
+                VALID_REPORT
+                + """
+## Source Attribution
+
+- **Markdown URL report**: [Example Source](https://example.test/report)
+""",
+                require_source_attribution=True,
+                source_attribution_requirements=[["https://example.test/report"]],
+            ),
+            [],
+        )
+
+    def test_url_requirement_allows_sentence_punctuation(self):
+        self.assertEqual(
+            validate_report_content(
+                VALID_REPORT
+                + """
+## Source Attribution
+
+- **Sentence URL report**: Example Source - https://example.test/report.
+""",
+                require_source_attribution=True,
+                source_attribution_requirements=[["https://example.test/report"]],
+            ),
+            [],
+        )
+
     def test_url_requirement_allows_parentheses_in_url(self):
         self.assertEqual(
             validate_report_content(

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -180,6 +180,22 @@ https://example.test/report
             [],
         )
 
+    def test_url_requirement_requires_exact_url_match(self):
+        issues = validate_report_content(
+            VALID_REPORT
+            + """
+## Source Attribution
+
+- **Longer URL report**: Example Source - https://example.test/reporting
+""",
+            require_source_attribution=True,
+            source_attribution_requirements=[["https://example.test/report"]],
+        )
+
+        self.assertTrue(
+            any(issue.code == "missing_source_attribution" for issue in issues)
+        )
+
     def test_source_only_article_requires_source_and_title(self):
         issues = validate_report_content(
             VALID_REPORT

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -187,6 +187,25 @@ https://example.test/report
             [],
         )
 
+    def test_source_only_markers_must_appear_in_same_attribution_entry(self):
+        issues = validate_report_content(
+            VALID_REPORT
+            + """
+## Source Attribution
+
+- **Source-only exploitation report**: Different Source
+- **Different report**: Example Source
+""",
+            require_source_attribution=True,
+            source_attribution_requirements=[
+                ["Example Source", "Source-only exploitation report"]
+            ],
+        )
+
+        self.assertTrue(
+            any(issue.code == "missing_source_attribution" for issue in issues)
+        )
+
     def test_api_error_marker_fails(self):
         issues = validate_report_content(
             "# Error Generating Exploitation Report\n\nError code: 404"

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -97,6 +97,23 @@ https://example.test/report
             any(issue.code == "missing_source_attribution" for issue in issues)
         )
 
+    def test_fenced_source_attribution_section_does_not_satisfy_requirement(self):
+        issues = validate_report_content(
+            VALID_REPORT + """
+```markdown
+## Source Attribution
+
+- **Example exploitation report**: Example Source - https://example.test/report
+```
+""",
+            require_source_attribution=True,
+            source_attribution_requirements=[["https://example.test/report"]],
+        )
+
+        self.assertTrue(
+            any(issue.code == "missing_source_attribution" for issue in issues)
+        )
+
     def test_placeholder_source_attribution_entry_fails(self):
         issues = validate_report_content(
             VALID_REPORT

--- a/tests/test_source_attribution.py
+++ b/tests/test_source_attribution.py
@@ -1,0 +1,40 @@
+import unittest
+
+from src.core.source_attribution import (
+    collect_source_attribution_entries,
+)
+
+
+class SourceAttributionTests(unittest.TestCase):
+    def test_unknown_source_sentinel_does_not_require_attribution(self):
+        self.assertEqual(
+            collect_source_attribution_entries(
+                [
+                    {
+                        "title": "Metadata-light report",
+                        "source": "Unknown Source",
+                        "summary": "Summary only",
+                    }
+                ]
+            ),
+            [],
+        )
+
+    def test_unknown_source_sentinel_does_not_replace_real_url_attribution(self):
+        self.assertEqual(
+            collect_source_attribution_entries(
+                [
+                    {
+                        "title": "URL-backed report",
+                        "source": "Unknown Source",
+                        "link": "https://example.test/report",
+                        "summary": "Summary only",
+                    }
+                ]
+            ),
+            ["- **URL-backed report**: https://example.test/report"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workflow_guards.py
+++ b/tests/test_workflow_guards.py
@@ -109,7 +109,7 @@ class WorkflowGuardTests(unittest.TestCase):
             state = {
                 "analysis_results": {
                     "exploitation_report": (
-                        "# Error Generating Exploitation Report\n\n" "Error code: 404"
+                        "# Error Generating Exploitation Report\n\nError code: 404"
                     )
                 },
                 "config": {"output_path": str(output_path)},
@@ -173,9 +173,6 @@ Recent exploitation activity is concentrated in edge systems.
 - **Unknown actor**: Opportunistic exploitation.
 """,
                     "source_attribution_required": True,
-                    "source_attribution_requirements": [
-                        ["https://example.test/report"]
-                    ],
                 },
                 "config": {"output_path": str(output_path)},
                 "status": "started",

--- a/tests/test_workflow_guards.py
+++ b/tests/test_workflow_guards.py
@@ -142,6 +142,51 @@ class WorkflowGuardTests(unittest.TestCase):
             self.assertEqual(result["status"], "completed_with_warnings")
             self.assertFalse(output_path.exists())
 
+    def test_missing_required_source_attribution_does_not_write_output_file(self):
+        workflow = import_workflow_with_stubs()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "index.md"
+            state = {
+                "analysis_results": {
+                    "exploitation_report": """# Exploitation Report
+
+Recent exploitation activity is concentrated in edge systems.
+
+## Active Exploitation Details
+
+### Example Vulnerability
+- **Description**: Attackers are exploiting a vulnerable service.
+- **Impact**: Remote access.
+- **Status**: Active exploitation observed.
+
+## Affected Systems and Products
+
+- **Example Product**: Affected versions are exposed.
+
+## Attack Vectors and Techniques
+
+- **Internet-facing service**: Attackers send crafted requests.
+
+## Threat Actor Activities
+
+- **Unknown actor**: Opportunistic exploitation.
+""",
+                    "source_attribution_required": True,
+                    "source_attribution_requirements": [
+                        ["https://example.test/report"]
+                    ],
+                },
+                "config": {"output_path": str(output_path)},
+                "status": "started",
+            }
+
+            result = asyncio.run(workflow.generate_report(state))
+
+            self.assertEqual(result["status"], "failed")
+            self.assertIn("report_validation_errors", result)
+            self.assertFalse(output_path.exists())
+
     def test_failed_state_skips_audio_generation(self):
         workflow = import_workflow_with_stubs()
         state = {


### PR DESCRIPTION
## Summary
- Require generated reports to include source attribution when article metadata is available.
- Validate source attribution against URL-first per-article requirements before writing or publishing reports.
- Add regression coverage for placeholder, negative, partial, repeated-source, heading-mention, and code-block attribution cases.

## Validation
- `uv run python -B -W error -m unittest tests.test_analyze_guards tests.test_report_validation tests.test_publish_guards tests.test_workflow_guards`
- `uv run ruff check .`
- `uv run black --workers 1 --check .`
- `uv run ty check`
- `git diff --check`
- `uv run python -B scripts/validate_report.py index.md`
- `uv run python -B scripts/validate_report.py docs/index.md`