### PR TITLE
Add report provenance panel

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -334,6 +334,30 @@
         body.dark .section-filter { background: var(--dark-elev); border-color: #1f2937; }
         body.dark .section-filter input { background: #0b1220; border-color: #1f2937; color: #e5e7eb; }
 
+        .provenance {
+            border: 1px solid var(--border-color);
+            background: #ffffff;
+            border-radius: 10px;
+            padding: 12px;
+            margin: 0 0 16px;
+        }
+        .provenance h4 {
+            margin: 0 0 6px;
+            color: var(--text-secondary);
+        }
+        .provenance p {
+            margin: 0;
+            color: var(--text-primary);
+        }
+        .provenance .provenance-meta {
+            color: var(--text-secondary);
+            font-size: 0.85rem;
+            margin-top: 6px;
+        }
+        body.dark .provenance { background: var(--dark-elev); border-color: #1f2937; }
+        body.dark .provenance h4 { color: #cbd5e1; }
+        body.dark .provenance p { color: #e5e7eb; }
+
         /* Add loading animation */
         .loading {
             text-align: center;
@@ -433,6 +457,7 @@
             <main>
                 <div class="meta" id="meta"></div>
                 <div id="summary" class="summary"></div>
+                <div id="provenance" class="provenance" hidden></div>
                 <div class="section-filter">
                     <label for="section-filter">Filter report sections</label>
                     <input id="section-filter" type="search" autocomplete="off" placeholder="Search vulnerabilities, products, actors, or techniques" />
@@ -450,6 +475,7 @@
         const tocEl = document.getElementById('toc-list');
         const metaEl = document.getElementById('meta');
         const summaryEl = document.getElementById('summary');
+        const provenanceEl = document.getElementById('provenance');
         const toggleDarkEl = document.getElementById('toggle-dark');
         const archiveLinkEl = document.getElementById('archive-link');
         const execEl = document.getElementById('exec');
@@ -750,6 +776,43 @@
             summaryEl.innerHTML = html;
         }
 
+        function findSourceAttributionHeading() {
+            return Array.from(contentEl.querySelectorAll('h2')).find(h => /source attribution/i.test(h.textContent));
+        }
+
+        function extractSourceAttributionEntries() {
+            const heading = findSourceAttributionHeading();
+            if (!heading) return [];
+            const entries = [];
+            let el = heading.nextElementSibling;
+            while (el && el.tagName !== 'H2') {
+                if (el.tagName === 'UL' || el.tagName === 'OL') {
+                    el.querySelectorAll('li').forEach(li => {
+                        const text = li.textContent.trim().replace(/\s+/g, ' ');
+                        if (text) entries.push(text);
+                    });
+                }
+                el = el.nextElementSibling;
+            }
+            return entries;
+        }
+
+        function renderProvenance() {
+            const sourceEntries = extractSourceAttributionEntries();
+            if (!sourceEntries.length) {
+                provenanceEl.hidden = true;
+                provenanceEl.innerHTML = '';
+                return;
+            }
+            provenanceEl.hidden = false;
+            const label = sourceEntries.length === 1 ? 'Source entry' : 'Source entries';
+            provenanceEl.innerHTML = `
+                <h4>Report Provenance</h4>
+                <p>${sourceEntries.length} ${label.toLowerCase()} cited in this report.</p>
+                <div class="provenance-meta">Source entries are rendered from the report's Source Attribution section.</div>
+            `;
+        }
+
         function buildFilterGroups() {
             const groups = [];
             let currentHeading = null;
@@ -907,6 +970,7 @@
                 enhanceActiveExploitationTags();
                 buildTOC();
                 computeSummary();
+                renderProvenance();
                 filterSections();
                 const m = text.match(/title:\s*Exploitation Intelligence Report\s*-\s*(\d{4}-\d{2}-\d{2})/i);
                 setMeta(m ? m[1] : '');

--- a/docs/index.html
+++ b/docs/index.html
@@ -784,6 +784,10 @@
             const normalized = text.trim().toLowerCase().replace(/\s+/g, ' ');
             return normalized === 'no sources were provided.' ||
                 normalized === 'no sources were provided' ||
+                normalized === 'none' ||
+                normalized === 'n/a' ||
+                normalized === '**article title**: source name - url' ||
+                normalized === 'article title: source name - url' ||
                 normalized.startsWith('no source attribution') ||
                 normalized.startsWith('no sources available') ||
                 normalized.startsWith('source attribution unavailable');

--- a/docs/index.html
+++ b/docs/index.html
@@ -780,6 +780,15 @@
             return Array.from(contentEl.querySelectorAll('h2')).find(h => /source attribution/i.test(h.textContent));
         }
 
+        function isPlaceholderSourceAttributionEntry(text) {
+            const normalized = text.trim().toLowerCase().replace(/\s+/g, ' ');
+            return normalized === 'no sources were provided.' ||
+                normalized === 'no sources were provided' ||
+                normalized.startsWith('no source attribution') ||
+                normalized.startsWith('no sources available') ||
+                normalized.startsWith('source attribution unavailable');
+        }
+
         function extractSourceAttributionEntries() {
             const heading = findSourceAttributionHeading();
             if (!heading) return [];
@@ -789,7 +798,7 @@
                 if (el.tagName === 'UL' || el.tagName === 'OL') {
                     el.querySelectorAll('li').forEach(li => {
                         const text = li.textContent.trim().replace(/\s+/g, ' ');
-                        if (text) entries.push(text);
+                        if (text && !isPlaceholderSourceAttributionEntry(text)) entries.push(text);
                     });
                 }
                 el = el.nextElementSibling;

--- a/index.html
+++ b/index.html
@@ -784,6 +784,10 @@
             const normalized = text.trim().toLowerCase().replace(/\s+/g, ' ');
             return normalized === 'no sources were provided.' ||
                 normalized === 'no sources were provided' ||
+                normalized === 'none' ||
+                normalized === 'n/a' ||
+                normalized === '**article title**: source name - url' ||
+                normalized === 'article title: source name - url' ||
                 normalized.startsWith('no source attribution') ||
                 normalized.startsWith('no sources available') ||
                 normalized.startsWith('source attribution unavailable');

--- a/index.html
+++ b/index.html
@@ -780,6 +780,15 @@
             return Array.from(contentEl.querySelectorAll('h2')).find(h => /source attribution/i.test(h.textContent));
         }
 
+        function isPlaceholderSourceAttributionEntry(text) {
+            const normalized = text.trim().toLowerCase().replace(/\s+/g, ' ');
+            return normalized === 'no sources were provided.' ||
+                normalized === 'no sources were provided' ||
+                normalized.startsWith('no source attribution') ||
+                normalized.startsWith('no sources available') ||
+                normalized.startsWith('source attribution unavailable');
+        }
+
         function extractSourceAttributionEntries() {
             const heading = findSourceAttributionHeading();
             if (!heading) return [];
@@ -789,7 +798,7 @@
                 if (el.tagName === 'UL' || el.tagName === 'OL') {
                     el.querySelectorAll('li').forEach(li => {
                         const text = li.textContent.trim().replace(/\s+/g, ' ');
-                        if (text) entries.push(text);
+                        if (text && !isPlaceholderSourceAttributionEntry(text)) entries.push(text);
                     });
                 }
                 el = el.nextElementSibling;

--- a/index.html
+++ b/index.html
@@ -334,6 +334,30 @@
         body.dark .section-filter { background: var(--dark-elev); border-color: #1f2937; }
         body.dark .section-filter input { background: #0b1220; border-color: #1f2937; color: #e5e7eb; }
 
+        .provenance {
+            border: 1px solid var(--border-color);
+            background: #ffffff;
+            border-radius: 10px;
+            padding: 12px;
+            margin: 0 0 16px;
+        }
+        .provenance h4 {
+            margin: 0 0 6px;
+            color: var(--text-secondary);
+        }
+        .provenance p {
+            margin: 0;
+            color: var(--text-primary);
+        }
+        .provenance .provenance-meta {
+            color: var(--text-secondary);
+            font-size: 0.85rem;
+            margin-top: 6px;
+        }
+        body.dark .provenance { background: var(--dark-elev); border-color: #1f2937; }
+        body.dark .provenance h4 { color: #cbd5e1; }
+        body.dark .provenance p { color: #e5e7eb; }
+
         /* Add loading animation */
         .loading {
             text-align: center;
@@ -433,6 +457,7 @@
             <main>
                 <div class="meta" id="meta"></div>
                 <div id="summary" class="summary"></div>
+                <div id="provenance" class="provenance" hidden></div>
                 <div class="section-filter">
                     <label for="section-filter">Filter report sections</label>
                     <input id="section-filter" type="search" autocomplete="off" placeholder="Search vulnerabilities, products, actors, or techniques" />
@@ -450,6 +475,7 @@
         const tocEl = document.getElementById('toc-list');
         const metaEl = document.getElementById('meta');
         const summaryEl = document.getElementById('summary');
+        const provenanceEl = document.getElementById('provenance');
         const toggleDarkEl = document.getElementById('toggle-dark');
         const archiveLinkEl = document.getElementById('archive-link');
         const execEl = document.getElementById('exec');
@@ -750,6 +776,43 @@
             summaryEl.innerHTML = html;
         }
 
+        function findSourceAttributionHeading() {
+            return Array.from(contentEl.querySelectorAll('h2')).find(h => /source attribution/i.test(h.textContent));
+        }
+
+        function extractSourceAttributionEntries() {
+            const heading = findSourceAttributionHeading();
+            if (!heading) return [];
+            const entries = [];
+            let el = heading.nextElementSibling;
+            while (el && el.tagName !== 'H2') {
+                if (el.tagName === 'UL' || el.tagName === 'OL') {
+                    el.querySelectorAll('li').forEach(li => {
+                        const text = li.textContent.trim().replace(/\s+/g, ' ');
+                        if (text) entries.push(text);
+                    });
+                }
+                el = el.nextElementSibling;
+            }
+            return entries;
+        }
+
+        function renderProvenance() {
+            const sourceEntries = extractSourceAttributionEntries();
+            if (!sourceEntries.length) {
+                provenanceEl.hidden = true;
+                provenanceEl.innerHTML = '';
+                return;
+            }
+            provenanceEl.hidden = false;
+            const label = sourceEntries.length === 1 ? 'Source entry' : 'Source entries';
+            provenanceEl.innerHTML = `
+                <h4>Report Provenance</h4>
+                <p>${sourceEntries.length} ${label.toLowerCase()} cited in this report.</p>
+                <div class="provenance-meta">Source entries are rendered from the report's Source Attribution section.</div>
+            `;
+        }
+
         function buildFilterGroups() {
             const groups = [];
             let currentHeading = null;
@@ -892,6 +955,7 @@
                 enhanceActiveExploitationTags();
                 buildTOC();
                 computeSummary();
+                renderProvenance();
                 filterSections();
                 const m = text.match(/title:\s*Exploitation Intelligence Report\s*-\s*(\d{4}-\d{2}-\d{2})/i);
                 setMeta(m ? m[1] : '');

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -100,3 +100,17 @@ def test_report_archive_route_has_static_index():
     assert "Report Archive" in archive
     assert "../index.html" in archive
     assert "index.md" in archive
+
+
+def test_report_viewers_include_source_provenance_panel():
+    for viewer_path in REPORT_VIEWERS:
+        viewer = viewer_path.read_text()
+
+        assert 'id="provenance"' in viewer
+        assert "Report Provenance" in viewer
+        assert "Source entries" in viewer
+        assert "extractSourceAttributionEntries" in viewer
+        assert "renderProvenance" in viewer
+        assert "findSourceAttributionHeading" in viewer
+        assert "provenanceEl.hidden = true" in viewer
+        assert "provenanceEl.hidden = false" in viewer

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -109,6 +109,8 @@ def test_report_viewers_include_source_provenance_panel():
         assert 'id="provenance"' in viewer
         assert "Report Provenance" in viewer
         assert "Source entries" in viewer
+        assert "isPlaceholderSourceAttributionEntry" in viewer
+        assert "no sources were provided" in viewer
         assert "extractSourceAttributionEntries" in viewer
         assert "renderProvenance" in viewer
         assert "findSourceAttributionHeading" in viewer

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -111,6 +111,8 @@ def test_report_viewers_include_source_provenance_panel():
         assert "Source entries" in viewer
         assert "isPlaceholderSourceAttributionEntry" in viewer
         assert "no sources were provided" in viewer
+        assert "article title: source name - url" in viewer
+        assert "n/a" in viewer
         assert "extractSourceAttributionEntries" in viewer
         assert "renderProvenance" in viewer
         assert "findSourceAttributionHeading" in viewer


### PR DESCRIPTION
## Summary
- Add a hidden-by-default provenance panel to the root and docs report viewers.
- Summarize Source Attribution entries when present while keeping the panel hidden for reports without attribution.
- Preserve the existing summary, archive, section filter, and sanitized markdown render path.

## Validation
- `uv run ruff check .`
- `uv run ty check`
- `git diff --check`
- Direct viewer guard runner for `tests/test_report_viewer_security.py`
- Playwright desktop/mobile render check for root and docs viewers