### PR TITLE
Add uncertainty signal panel

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -358,6 +358,30 @@
         body.dark .provenance h4 { color: #cbd5e1; }
         body.dark .provenance p { color: #e5e7eb; }
 
+        .uncertainty {
+            border: 1px solid var(--border-color);
+            background: #ffffff;
+            border-radius: 10px;
+            padding: 12px;
+            margin: 0 0 16px;
+        }
+        .uncertainty h4 {
+            margin: 0 0 6px;
+            color: var(--text-secondary);
+        }
+        .uncertainty p {
+            margin: 0;
+            color: var(--text-primary);
+        }
+        .uncertainty .uncertainty-meta {
+            color: var(--text-secondary);
+            font-size: 0.85rem;
+            margin-top: 6px;
+        }
+        body.dark .uncertainty { background: var(--dark-elev); border-color: #1f2937; }
+        body.dark .uncertainty h4 { color: #cbd5e1; }
+        body.dark .uncertainty p { color: #e5e7eb; }
+
         /* Add loading animation */
         .loading {
             text-align: center;
@@ -458,6 +482,7 @@
                 <div class="meta" id="meta"></div>
                 <div id="summary" class="summary"></div>
                 <div id="provenance" class="provenance" hidden></div>
+                <div id="uncertainty" class="uncertainty" hidden></div>
                 <div class="section-filter">
                     <label for="section-filter">Filter report sections</label>
                     <input id="section-filter" type="search" autocomplete="off" placeholder="Search vulnerabilities, products, actors, or techniques" />
@@ -476,6 +501,7 @@
         const metaEl = document.getElementById('meta');
         const summaryEl = document.getElementById('summary');
         const provenanceEl = document.getElementById('provenance');
+        const uncertaintyEl = document.getElementById('uncertainty');
         const toggleDarkEl = document.getElementById('toggle-dark');
         const archiveLinkEl = document.getElementById('archive-link');
         const execEl = document.getElementById('exec');
@@ -826,6 +852,27 @@
             `;
         }
 
+        function countUncertaintySignals() {
+            const matches = markdownCache.match(/\b(unknown|uncertain|suspected|likely|possible|potential|could)\b/gi) || [];
+            return matches.length;
+        }
+
+        function renderUncertaintySignals() {
+            const signalCount = countUncertaintySignals();
+            if (!signalCount) {
+                uncertaintyEl.hidden = true;
+                uncertaintyEl.innerHTML = '';
+                return;
+            }
+            uncertaintyEl.hidden = false;
+            const label = signalCount === 1 ? 'uncertainty signal' : 'uncertainty signals';
+            uncertaintyEl.innerHTML = `
+                <h4>Uncertainty Signals</h4>
+                <p>${signalCount} ${label} detected in this report.</p>
+                <div class="uncertainty-meta">Counted from report wording such as unknown, suspected, likely, possible, potential, or could.</div>
+            `;
+        }
+
         function buildFilterGroups() {
             const groups = [];
             let currentHeading = null;
@@ -984,6 +1031,7 @@
                 buildTOC();
                 computeSummary();
                 renderProvenance();
+                renderUncertaintySignals();
                 filterSections();
                 const m = text.match(/title:\s*Exploitation Intelligence Report\s*-\s*(\d{4}-\d{2}-\d{2})/i);
                 setMeta(m ? m[1] : '');

--- a/docs/index.html
+++ b/docs/index.html
@@ -853,7 +853,8 @@
         }
 
         function countUncertaintySignals() {
-            const matches = markdownCache.match(/\b(unknown|uncertain|suspected|likely|possible|potential|could)\b/gi) || [];
+            const reportText = contentEl.textContent || '';
+            const matches = reportText.match(/\b(unknown|uncertain|suspected|likely|possible|potential|could)\b/gi) || [];
             return matches.length;
         }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -852,8 +852,17 @@
             `;
         }
 
+        function getVisibleReportText() {
+            const textRoots = [execEl, contentEl];
+            return textRoots.map(root => {
+                const clone = root.cloneNode(true);
+                clone.querySelectorAll('code, pre, script, style, noscript').forEach(node => node.remove());
+                return clone.textContent || '';
+            }).join(' ');
+        }
+
         function countUncertaintySignals() {
-            const reportText = contentEl.textContent || '';
+            const reportText = getVisibleReportText();
             const matches = reportText.match(/\b(unknown|uncertain|suspected|likely|possible|potential|could)\b/gi) || [];
             return matches.length;
         }

--- a/index.html
+++ b/index.html
@@ -853,7 +853,8 @@
         }
 
         function countUncertaintySignals() {
-            const matches = markdownCache.match(/\b(unknown|uncertain|suspected|likely|possible|potential|could)\b/gi) || [];
+            const reportText = contentEl.textContent || '';
+            const matches = reportText.match(/\b(unknown|uncertain|suspected|likely|possible|potential|could)\b/gi) || [];
             return matches.length;
         }
 

--- a/index.html
+++ b/index.html
@@ -852,8 +852,17 @@
             `;
         }
 
+        function getVisibleReportText() {
+            const textRoots = [execEl, contentEl];
+            return textRoots.map(root => {
+                const clone = root.cloneNode(true);
+                clone.querySelectorAll('code, pre, script, style, noscript').forEach(node => node.remove());
+                return clone.textContent || '';
+            }).join(' ');
+        }
+
         function countUncertaintySignals() {
-            const reportText = contentEl.textContent || '';
+            const reportText = getVisibleReportText();
             const matches = reportText.match(/\b(unknown|uncertain|suspected|likely|possible|potential|could)\b/gi) || [];
             return matches.length;
         }

--- a/index.html
+++ b/index.html
@@ -358,6 +358,30 @@
         body.dark .provenance h4 { color: #cbd5e1; }
         body.dark .provenance p { color: #e5e7eb; }
 
+        .uncertainty {
+            border: 1px solid var(--border-color);
+            background: #ffffff;
+            border-radius: 10px;
+            padding: 12px;
+            margin: 0 0 16px;
+        }
+        .uncertainty h4 {
+            margin: 0 0 6px;
+            color: var(--text-secondary);
+        }
+        .uncertainty p {
+            margin: 0;
+            color: var(--text-primary);
+        }
+        .uncertainty .uncertainty-meta {
+            color: var(--text-secondary);
+            font-size: 0.85rem;
+            margin-top: 6px;
+        }
+        body.dark .uncertainty { background: var(--dark-elev); border-color: #1f2937; }
+        body.dark .uncertainty h4 { color: #cbd5e1; }
+        body.dark .uncertainty p { color: #e5e7eb; }
+
         /* Add loading animation */
         .loading {
             text-align: center;
@@ -458,6 +482,7 @@
                 <div class="meta" id="meta"></div>
                 <div id="summary" class="summary"></div>
                 <div id="provenance" class="provenance" hidden></div>
+                <div id="uncertainty" class="uncertainty" hidden></div>
                 <div class="section-filter">
                     <label for="section-filter">Filter report sections</label>
                     <input id="section-filter" type="search" autocomplete="off" placeholder="Search vulnerabilities, products, actors, or techniques" />
@@ -476,6 +501,7 @@
         const metaEl = document.getElementById('meta');
         const summaryEl = document.getElementById('summary');
         const provenanceEl = document.getElementById('provenance');
+        const uncertaintyEl = document.getElementById('uncertainty');
         const toggleDarkEl = document.getElementById('toggle-dark');
         const archiveLinkEl = document.getElementById('archive-link');
         const execEl = document.getElementById('exec');
@@ -826,6 +852,27 @@
             `;
         }
 
+        function countUncertaintySignals() {
+            const matches = markdownCache.match(/\b(unknown|uncertain|suspected|likely|possible|potential|could)\b/gi) || [];
+            return matches.length;
+        }
+
+        function renderUncertaintySignals() {
+            const signalCount = countUncertaintySignals();
+            if (!signalCount) {
+                uncertaintyEl.hidden = true;
+                uncertaintyEl.innerHTML = '';
+                return;
+            }
+            uncertaintyEl.hidden = false;
+            const label = signalCount === 1 ? 'uncertainty signal' : 'uncertainty signals';
+            uncertaintyEl.innerHTML = `
+                <h4>Uncertainty Signals</h4>
+                <p>${signalCount} ${label} detected in this report.</p>
+                <div class="uncertainty-meta">Counted from report wording such as unknown, suspected, likely, possible, potential, or could.</div>
+            `;
+        }
+
         function buildFilterGroups() {
             const groups = [];
             let currentHeading = null;
@@ -969,6 +1016,7 @@
                 buildTOC();
                 computeSummary();
                 renderProvenance();
+                renderUncertaintySignals();
                 filterSections();
                 const m = text.match(/title:\s*Exploitation Intelligence Report\s*-\s*(\d{4}-\d{2}-\d{2})/i);
                 setMeta(m ? m[1] : '');

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -135,6 +135,8 @@ def test_report_viewers_include_uncertainty_signal_panel():
         assert "Uncertainty Signals" in viewer
         assert "countUncertaintySignals" in viewer
         assert "renderUncertaintySignals" in viewer
+        assert "const reportText = contentEl.textContent || ''" in viewer
+        assert "markdownCache.match(/\\b(unknown|uncertain" not in viewer
         assert "uncertaintyEl.hidden = true" in viewer
         assert "uncertaintyEl.hidden = false" in viewer
         assert "unknown|uncertain|suspected|likely|possible|potential|could" in viewer

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -125,3 +125,17 @@ def test_report_viewers_include_source_provenance_panel():
         assert "findSourceAttributionHeading" in viewer
         assert "provenanceEl.hidden = true" in viewer
         assert "provenanceEl.hidden = false" in viewer
+
+
+def test_report_viewers_include_uncertainty_signal_panel():
+    for viewer_path in REPORT_VIEWERS:
+        viewer = viewer_path.read_text()
+
+        assert 'id="uncertainty"' in viewer
+        assert "Uncertainty Signals" in viewer
+        assert "countUncertaintySignals" in viewer
+        assert "renderUncertaintySignals" in viewer
+        assert "uncertaintyEl.hidden = true" in viewer
+        assert "uncertaintyEl.hidden = false" in viewer
+        assert "unknown|uncertain|suspected|likely|possible|potential|could" in viewer
+        assert "potential, or could" in viewer

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -135,7 +135,11 @@ def test_report_viewers_include_uncertainty_signal_panel():
         assert "Uncertainty Signals" in viewer
         assert "countUncertaintySignals" in viewer
         assert "renderUncertaintySignals" in viewer
-        assert "const reportText = contentEl.textContent || ''" in viewer
+        assert "getVisibleReportText" in viewer
+        assert "const textRoots = [execEl, contentEl]" in viewer
+        assert "code, pre, script, style, noscript" in viewer
+        assert "const reportText = getVisibleReportText()" in viewer
+        assert "const reportText = contentEl.textContent || ''" not in viewer
         assert "markdownCache.match(/\\b(unknown|uncertain" not in viewer
         assert "uncertaintyEl.hidden = true" in viewer
         assert "uncertaintyEl.hidden = false" in viewer


### PR DESCRIPTION
## Summary
- Add a hidden-by-default uncertainty signal panel to the root and docs report viewers.
- Derive the signal count from report wording instead of adding new report claims.
- Add a static guard for the uncertainty panel surface.

## Validation
- `uv run ruff check .`
- `uv run ty check`
- `git diff --check`
- Direct viewer guard runner for `tests/test_report_viewer_security.py`
- Desktop/mobile render check for visible current-report state and hidden no-signal state