### PR TITLE
Add source preview to report provenance

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -354,6 +354,23 @@
             font-size: 0.85rem;
             margin-top: 6px;
         }
+        .source-preview {
+            margin-top: 10px;
+        }
+        .source-preview summary {
+            cursor: pointer;
+            color: var(--accent-color);
+            font-weight: 600;
+        }
+        .source-preview ul {
+            margin: 8px 0 0;
+            padding-left: 20px;
+            color: var(--text-primary);
+        }
+        .source-preview li {
+            margin: 4px 0;
+            overflow-wrap: anywhere;
+        }
         body.dark .provenance { background: var(--dark-elev); border-color: #1f2937; }
         body.dark .provenance h4 { color: #cbd5e1; }
         body.dark .provenance p { color: #e5e7eb; }
@@ -836,6 +853,26 @@
             return entries;
         }
 
+        function renderSourcePreview(sourceEntries) {
+            const preview = document.createElement('details');
+            preview.className = 'source-preview';
+
+            const summary = document.createElement('summary');
+            summary.textContent = 'View source entries';
+            preview.appendChild(summary);
+
+            const sourcePreviewList = document.createElement('ul');
+            sourcePreviewList.innerHTML = '';
+            sourceEntries.forEach(entry => {
+                const entryEl = document.createElement('li');
+                entryEl.textContent = entry;
+                sourcePreviewList.appendChild(entryEl);
+            });
+            preview.appendChild(sourcePreviewList);
+
+            return preview;
+        }
+
         function renderProvenance() {
             const sourceEntries = extractSourceAttributionEntries();
             if (!sourceEntries.length) {
@@ -850,6 +887,7 @@
                 <p>${sourceEntries.length} ${label.toLowerCase()} cited in this report.</p>
                 <div class="provenance-meta">Source entries are rendered from the report's Source Attribution section.</div>
             `;
+            provenanceEl.appendChild(renderSourcePreview(sourceEntries));
         }
 
         function getVisibleReportText() {

--- a/index.html
+++ b/index.html
@@ -354,6 +354,23 @@
             font-size: 0.85rem;
             margin-top: 6px;
         }
+        .source-preview {
+            margin-top: 10px;
+        }
+        .source-preview summary {
+            cursor: pointer;
+            color: var(--accent-color);
+            font-weight: 600;
+        }
+        .source-preview ul {
+            margin: 8px 0 0;
+            padding-left: 20px;
+            color: var(--text-primary);
+        }
+        .source-preview li {
+            margin: 4px 0;
+            overflow-wrap: anywhere;
+        }
         body.dark .provenance { background: var(--dark-elev); border-color: #1f2937; }
         body.dark .provenance h4 { color: #cbd5e1; }
         body.dark .provenance p { color: #e5e7eb; }
@@ -836,6 +853,26 @@
             return entries;
         }
 
+        function renderSourcePreview(sourceEntries) {
+            const preview = document.createElement('details');
+            preview.className = 'source-preview';
+
+            const summary = document.createElement('summary');
+            summary.textContent = 'View source entries';
+            preview.appendChild(summary);
+
+            const sourcePreviewList = document.createElement('ul');
+            sourcePreviewList.innerHTML = '';
+            sourceEntries.forEach(entry => {
+                const entryEl = document.createElement('li');
+                entryEl.textContent = entry;
+                sourcePreviewList.appendChild(entryEl);
+            });
+            preview.appendChild(sourcePreviewList);
+
+            return preview;
+        }
+
         function renderProvenance() {
             const sourceEntries = extractSourceAttributionEntries();
             if (!sourceEntries.length) {
@@ -850,6 +887,7 @@
                 <p>${sourceEntries.length} ${label.toLowerCase()} cited in this report.</p>
                 <div class="provenance-meta">Source entries are rendered from the report's Source Attribution section.</div>
             `;
+            provenanceEl.appendChild(renderSourcePreview(sourceEntries));
         }
 
         function getVisibleReportText() {

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -122,6 +122,11 @@ def test_report_viewers_include_source_provenance_panel():
         assert "n/a" in viewer
         assert "extractSourceAttributionEntries" in viewer
         assert "renderProvenance" in viewer
+        assert "renderSourcePreview" in viewer
+        assert "source-preview" in viewer
+        assert "sourcePreviewList" in viewer
+        assert "entryEl.textContent = entry" in viewer
+        assert "sourcePreviewList.innerHTML = ''" in viewer
         assert "findSourceAttributionHeading" in viewer
         assert "provenanceEl.hidden = true" in viewer
         assert "provenanceEl.hidden = false" in viewer


### PR DESCRIPTION
## Summary
- Adds an expandable source-entry preview to the report provenance panel.
- Keeps source entries text-rendered instead of injecting them as raw HTML.
- Updates the static viewer guard for both report viewer copies.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_viewer_security.py -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`
- `git diff --check`
- Browser rendered QA for root/docs viewers at desktop and mobile sizes