### PR TITLE
Route archive reports through reader

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -548,9 +548,11 @@
                 !requestedReport.includes('..') &&
                 !requestedReport.includes('?') &&
                 !requestedReport.includes('#') &&
+                !requestedReport.includes('%') &&
                 !requestedReport.startsWith('/') &&
                 !requestedReport.includes(':') &&
-                (requestedReport.startsWith('reports/') || requestedReport.startsWith('docs/reports/'))
+                (requestedReport.startsWith('reports/') || requestedReport.startsWith('docs/reports/')) &&
+                requestedReport.split('/').every(segment => segment && segment !== '.' && segment !== '..')
             ) {
                 return requestedReport;
             }
@@ -1127,7 +1129,7 @@
             const a = e.target.closest('a.heading-anchor');
             if (!a) return;
             e.preventDefault();
-            const url = `${location.origin}${location.pathname}${a.getAttribute('href')}`;
+            const url = `${location.origin}${location.pathname}${location.search}${a.getAttribute('href')}`;
             navigator.clipboard.writeText(url).then(() => showToast('Link copied to clipboard'));
         });
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -546,6 +546,8 @@
             if (
                 requestedReport.endsWith('.md') &&
                 !requestedReport.includes('..') &&
+                !requestedReport.includes('?') &&
+                !requestedReport.includes('#') &&
                 !requestedReport.startsWith('/') &&
                 !requestedReport.includes(':') &&
                 (requestedReport.startsWith('reports/') || requestedReport.startsWith('docs/reports/'))
@@ -1033,8 +1035,10 @@
 
         // Fetch and render the markdown content (after UI config)
         let markdownCache = '';
+        const reportPath = resolveReportPath();
+        const isArchiveReport = reportPath !== 'index.md';
         Promise.all([configPromise])
-          .then(() => fetch(resolveReportPath() + '?v=' + Date.now(), { cache: 'no-store' }))
+          .then(() => fetch(reportPath + '?v=' + Date.now(), { cache: 'no-store' }))
           .then(response => response.text())
           .then(text => {
                 markdownCache = text;
@@ -1050,23 +1054,25 @@
                         execEl.innerHTML = `<h4>Executive Summary</h4>`;
                         execEl.appendChild(next.cloneNode(true));
                         next.remove();
-                        // Add audio player for narrated executive summary
-                        const audioDiv = document.createElement('div');
-                        audioDiv.className = 'audio-player';
-                        const audioEl = document.createElement('audio');
-                        audioEl.controls = true;
-                        audioEl.preload = 'none';
-                        audioEl.src = 'executive_summary.mp3?v=' + Date.now();
-                        // Only show the player if the audio file exists
-                        audioEl.addEventListener('error', () => { audioDiv.style.display = 'none'; });
-                        audioDiv.appendChild(audioEl);
-                        execEl.appendChild(audioDiv);
+                        if (!isArchiveReport) {
+                            // Add audio player for narrated executive summary
+                            const audioDiv = document.createElement('div');
+                            audioDiv.className = 'audio-player';
+                            const audioEl = document.createElement('audio');
+                            audioEl.controls = true;
+                            audioEl.preload = 'none';
+                            audioEl.src = 'executive_summary.mp3?v=' + Date.now();
+                            // Only show the player if the audio file exists
+                            audioEl.addEventListener('error', () => { audioDiv.style.display = 'none'; });
+                            audioDiv.appendChild(audioEl);
+                            execEl.appendChild(audioDiv);
+                        }
                     }
                 }
 
                 // Inject podcast player after Threat Actor Activities heading
                 const threatH2 = Array.from(contentEl.querySelectorAll('h2')).find(h => /threat actor activities/i.test(h.textContent));
-                if (threatH2) {
+                if (!isArchiveReport && threatH2) {
                     const podDiv = document.createElement('div');
                     podDiv.className = 'audio-player';
                     podDiv.style.margin = '8px 0 16px';

--- a/docs/index.html
+++ b/docs/index.html
@@ -540,6 +540,21 @@
             return text.toLowerCase().replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-').substring(0, 80);
         }
 
+        function resolveReportPath() {
+            const params = new URLSearchParams(window.location.search);
+            const requestedReport = (params.get('report') || '').trim();
+            if (
+                requestedReport.endsWith('.md') &&
+                !requestedReport.includes('..') &&
+                !requestedReport.startsWith('/') &&
+                !requestedReport.includes(':') &&
+                (requestedReport.startsWith('reports/') || requestedReport.startsWith('docs/reports/'))
+            ) {
+                return requestedReport;
+            }
+            return 'index.md';
+        }
+
         function resolveArchiveLink() {
             const candidates = ['reports/', 'docs/reports/'];
             function probe(index) {
@@ -1019,7 +1034,7 @@
         // Fetch and render the markdown content (after UI config)
         let markdownCache = '';
         Promise.all([configPromise])
-          .then(() => fetch('index.md?v=' + Date.now(), { cache: 'no-store' }))
+          .then(() => fetch(resolveReportPath() + '?v=' + Date.now(), { cache: 'no-store' }))
           .then(response => response.text())
           .then(text => {
                 markdownCache = text;

--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -147,7 +147,7 @@
         </div>
         <section class="archive-list" aria-label="Available reports">
             <article class="archive-item" data-search="exploitation report citrixbleed netscaler cve-2025-5777 lapdogs soho routers moveit transfer">
-                <h2><a href="index.md">Exploitation report: CitrixBleed 2, LapDogs routers, and MOVEit scanning</a></h2>
+                <h2><a href="../index.html?report=reports/index.md">Exploitation report: CitrixBleed 2, LapDogs routers, and MOVEit scanning</a></h2>
                 <p>Archived generated report covering active exploitation of network-edge infrastructure and file-transfer systems.</p>
                 <div class="archive-tags" aria-label="Report topics">
                     <span class="archive-tag">CVE-2025-5777</span>

--- a/index.html
+++ b/index.html
@@ -546,6 +546,8 @@
             if (
                 requestedReport.endsWith('.md') &&
                 !requestedReport.includes('..') &&
+                !requestedReport.includes('?') &&
+                !requestedReport.includes('#') &&
                 !requestedReport.startsWith('/') &&
                 !requestedReport.includes(':') &&
                 (requestedReport.startsWith('reports/') || requestedReport.startsWith('docs/reports/'))
@@ -1033,8 +1035,10 @@
 
         // Fetch and render the markdown content (after UI config)
         let markdownCache = '';
+        const reportPath = resolveReportPath();
+        const isArchiveReport = reportPath !== 'index.md';
         Promise.all([configPromise])
-          .then(() => fetch(resolveReportPath() + '?v=' + Date.now(), { cache: 'no-store' }))
+          .then(() => fetch(reportPath + '?v=' + Date.now(), { cache: 'no-store' }))
           .then(response => response.text())
           .then(text => {
                 markdownCache = text;
@@ -1050,21 +1054,23 @@
                         execEl.innerHTML = `<h4>Executive Summary</h4>`;
                         execEl.appendChild(next.cloneNode(true));
                         next.remove();
-                        // Add audio player only if the file exists and has content
-                        const audioSrc = 'executive_summary.mp3?v=' + Date.now();
-                        fetch('executive_summary.mp3', { method: 'HEAD' }).then(r => {
-                            if (!r.ok) return;
-                            const len = parseInt(r.headers.get('Content-Length') || '0');
-                            if (len === 0) return;
-                            const audioDiv = document.createElement('div');
-                            audioDiv.className = 'audio-player';
-                            const audioEl = document.createElement('audio');
-                            audioEl.controls = true;
-                            audioEl.preload = 'none';
-                            audioEl.src = audioSrc;
-                            audioDiv.appendChild(audioEl);
-                            execEl.appendChild(audioDiv);
-                        }).catch(() => {});
+                        if (!isArchiveReport) {
+                            // Add audio player only if the file exists and has content
+                            const audioSrc = 'executive_summary.mp3?v=' + Date.now();
+                            fetch('executive_summary.mp3', { method: 'HEAD' }).then(r => {
+                                if (!r.ok) return;
+                                const len = parseInt(r.headers.get('Content-Length') || '0');
+                                if (len === 0) return;
+                                const audioDiv = document.createElement('div');
+                                audioDiv.className = 'audio-player';
+                                const audioEl = document.createElement('audio');
+                                audioEl.controls = true;
+                                audioEl.preload = 'none';
+                                audioEl.src = audioSrc;
+                                audioDiv.appendChild(audioEl);
+                                execEl.appendChild(audioDiv);
+                            }).catch(() => {});
+                        }
                     }
                 }
 

--- a/index.html
+++ b/index.html
@@ -540,6 +540,21 @@
             return text.toLowerCase().replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-').substring(0, 80);
         }
 
+        function resolveReportPath() {
+            const params = new URLSearchParams(window.location.search);
+            const requestedReport = (params.get('report') || '').trim();
+            if (
+                requestedReport.endsWith('.md') &&
+                !requestedReport.includes('..') &&
+                !requestedReport.startsWith('/') &&
+                !requestedReport.includes(':') &&
+                (requestedReport.startsWith('reports/') || requestedReport.startsWith('docs/reports/'))
+            ) {
+                return requestedReport;
+            }
+            return 'index.md';
+        }
+
         function resolveArchiveLink() {
             const candidates = ['reports/', 'docs/reports/'];
             function probe(index) {
@@ -1019,7 +1034,7 @@
         // Fetch and render the markdown content (after UI config)
         let markdownCache = '';
         Promise.all([configPromise])
-          .then(() => fetch('index.md?v=' + Date.now(), { cache: 'no-store' }))
+          .then(() => fetch(resolveReportPath() + '?v=' + Date.now(), { cache: 'no-store' }))
           .then(response => response.text())
           .then(text => {
                 markdownCache = text;

--- a/index.html
+++ b/index.html
@@ -548,9 +548,11 @@
                 !requestedReport.includes('..') &&
                 !requestedReport.includes('?') &&
                 !requestedReport.includes('#') &&
+                !requestedReport.includes('%') &&
                 !requestedReport.startsWith('/') &&
                 !requestedReport.includes(':') &&
-                (requestedReport.startsWith('reports/') || requestedReport.startsWith('docs/reports/'))
+                (requestedReport.startsWith('reports/') || requestedReport.startsWith('docs/reports/')) &&
+                requestedReport.split('/').every(segment => segment && segment !== '.' && segment !== '..')
             ) {
                 return requestedReport;
             }
@@ -1112,7 +1114,7 @@
             const a = e.target.closest('a.heading-anchor');
             if (!a) return;
             e.preventDefault();
-            const url = `${location.origin}${location.pathname}${a.getAttribute('href')}`;
+            const url = `${location.origin}${location.pathname}${location.search}${a.getAttribute('href')}`;
             navigator.clipboard.writeText(url).then(() => showToast('Link copied to clipboard'));
         });
 

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -92,6 +92,9 @@ def test_report_viewers_include_archive_navigation_affordance():
         assert "requestedReport.endsWith('.md')" in viewer
         assert "!requestedReport.includes('?')" in viewer
         assert "!requestedReport.includes('#')" in viewer
+        assert "!requestedReport.includes('%')" in viewer
+        assert "requestedReport.split('/')" in viewer
+        assert "segment !== '..'" in viewer
         assert "return 'index.md'" in viewer
         assert "const reportPath = resolveReportPath()" in viewer
         assert "const isArchiveReport = reportPath !== 'index.md'" in viewer
@@ -103,6 +106,7 @@ def test_report_viewers_include_archive_navigation_affordance():
         assert "function probe(index)" in viewer
         assert "probe(index + 1)" in viewer
         assert "archiveLinkEl.hidden = false" in viewer
+        assert "location.search" in viewer
 
 
 def test_report_archive_route_has_static_index():

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -85,6 +85,12 @@ def test_report_viewers_include_archive_navigation_affordance():
         viewer = viewer_path.read_text()
 
         assert 'id="archive-link"' in viewer
+        assert "resolveReportPath" in viewer
+        assert "new URLSearchParams(window.location.search)" in viewer
+        assert "requestedReport.startsWith('reports/')" in viewer
+        assert "requestedReport.startsWith('docs/reports/')" in viewer
+        assert "requestedReport.endsWith('.md')" in viewer
+        assert "return 'index.md'" in viewer
         assert "resolveArchiveLink" in viewer
         assert "reports/" in viewer
         assert "docs/reports/" in viewer
@@ -99,6 +105,7 @@ def test_report_archive_route_has_static_index():
 
     assert "Report Archive" in archive
     assert "../index.html" in archive
+    assert "../index.html?report=reports/index.md" in archive
     assert "index.md" in archive
     assert 'id="archive-filter"' in archive
     assert 'id="archive-count"' in archive

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -90,7 +90,12 @@ def test_report_viewers_include_archive_navigation_affordance():
         assert "requestedReport.startsWith('reports/')" in viewer
         assert "requestedReport.startsWith('docs/reports/')" in viewer
         assert "requestedReport.endsWith('.md')" in viewer
+        assert "!requestedReport.includes('?')" in viewer
+        assert "!requestedReport.includes('#')" in viewer
         assert "return 'index.md'" in viewer
+        assert "const reportPath = resolveReportPath()" in viewer
+        assert "const isArchiveReport = reportPath !== 'index.md'" in viewer
+        assert "if (!isArchiveReport)" in viewer
         assert "resolveArchiveLink" in viewer
         assert "reports/" in viewer
         assert "docs/reports/" in viewer


### PR DESCRIPTION
## Summary
- Routes archive report cards into the styled report reader instead of raw Markdown.
- Adds a constrained `?report=` markdown path resolver with default fallback.
- Updates static guards for the archive reader route.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_viewer_security.py -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`
- `git diff --check`
- Browser rendered QA for archive and reader routes at desktop and mobile sizes