### PR TITLE
Add archive clear filters

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -109,6 +109,22 @@
             border-color: #fca5a5;
             color: #991b1b;
         }
+        .archive-clear-filters {
+            background: transparent;
+            border: 0;
+            color: var(--accent);
+            cursor: pointer;
+            font: inherit;
+            font-size: 0.86rem;
+            font-weight: 700;
+            margin: 10px 0 0;
+            padding: 0;
+        }
+        .archive-clear-filters:disabled {
+            color: var(--muted);
+            cursor: default;
+            opacity: 0.65;
+        }
         .archive-item {
             background: var(--panel);
             border: 1px solid var(--border);
@@ -181,6 +197,7 @@
                 <button type="button" data-topic="LapDogs" aria-pressed="false">LapDogs</button>
                 <button type="button" data-topic="MOVEit" aria-pressed="false">MOVEit</button>
             </div>
+            <button class="archive-clear-filters" id="archive-clear-filters" type="button" disabled>Clear filters</button>
             <div class="archive-count" id="archive-count">1 report available</div>
         </div>
         <section class="archive-list" id="archive-list" aria-label="Available reports">
@@ -204,6 +221,7 @@
         const archiveEmptyEl = document.getElementById('archive-empty');
         const archiveListEl = document.getElementById('archive-list');
         const archiveTopicFiltersEl = document.getElementById('archive-topic-filters');
+        const archiveClearFiltersEl = document.getElementById('archive-clear-filters');
         const archiveTopicButtons = Array.from(archiveTopicFiltersEl.querySelectorAll('button'));
         const archiveItems = Array.from(document.querySelectorAll('.archive-item'));
         let activeTopic = '';
@@ -228,6 +246,7 @@
             });
             archiveCountEl.textContent = `${visible} ${visible === 1 ? 'report' : 'reports'} shown`;
             archiveEmptyEl.hidden = visible !== 0;
+            archiveClearFiltersEl.disabled = !query && !activeTopic;
         }
 
         function filterArchiveByTopic(topic) {
@@ -238,7 +257,13 @@
             filterArchive();
         }
 
+        function clearArchiveFilters() {
+            archiveFilterEl.value = '';
+            filterArchiveByTopic('');
+        }
+
         archiveFilterEl.addEventListener('input', filterArchive);
+        archiveClearFiltersEl.addEventListener('click', clearArchiveFilters);
         archiveTopicButtons.forEach(button => {
             button.addEventListener('click', () => filterArchiveByTopic(button.dataset.topic || ''));
         });

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -127,6 +127,9 @@ def test_report_archive_route_has_static_index():
     assert 'id="archive-topic-filters"' in archive
     assert "filterArchiveByTopic" in archive
     assert "aria-pressed" in archive
+    assert 'id="archive-clear-filters"' in archive
+    assert "clearArchiveFilters" in archive
+    assert "archiveClearFiltersEl.disabled" in archive
     assert "CVE-2025-5777" in archive
     assert "archiveEmptyEl.hidden = visible !== 0" in archive
 


### PR DESCRIPTION
## Summary
- Add a clear-filters control to the report archive.
- Reset archive search and active topic filters together.
- Disable the clear control when no archive filters are active.

## Validation
- uv run python -B -W error -m pytest tests/test_report_viewer_security.py::test_report_archive_route_has_static_index -q -p no:cacheprovider
- bash scripts/local_validation.sh
- Browser desktop and mobile archive interaction checks