### PR TITLE
Fix archived report metadata

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -802,10 +802,14 @@
             });
         }
 
-        function setMeta(dateStr) {
+        function renderReportMetadata(dateStr, archiveReport) {
             const d = new Date();
             const now = d.toLocaleString();
-            metaEl.textContent = `Last updated: ${dateStr || now}`;
+            if (archiveReport) {
+                metaEl.textContent = 'Archived report';
+                return;
+            }
+            metaEl.textContent = `Latest report · Last updated: ${dateStr || now}`;
         }
 
         function computeSummary() {
@@ -1105,7 +1109,7 @@
                 renderUncertaintySignals();
                 filterSections();
                 const m = text.match(/title:\s*Exploitation Intelligence Report\s*-\s*(\d{4}-\d{2}-\d{2})/i);
-                setMeta(m ? m[1] : '');
+                renderReportMetadata(m ? m[1] : '', isArchiveReport);
           })
             .catch(error => {
                 contentEl.innerHTML = `

--- a/index.html
+++ b/index.html
@@ -802,10 +802,14 @@
             });
         }
 
-        function setMeta(dateStr) {
+        function renderReportMetadata(dateStr, archiveReport) {
             const d = new Date();
             const now = d.toLocaleString();
-            metaEl.textContent = `Last updated: ${dateStr || now}`;
+            if (archiveReport) {
+                metaEl.textContent = 'Archived report';
+                return;
+            }
+            metaEl.textContent = `Latest report · Last updated: ${dateStr || now}`;
         }
 
         function computeSummary() {
@@ -1090,7 +1094,7 @@
                 renderUncertaintySignals();
                 filterSections();
                 const m = text.match(/title:\s*Exploitation Intelligence Report\s*-\s*(\d{4}-\d{2}-\d{2})/i);
-                setMeta(m ? m[1] : '');
+                renderReportMetadata(m ? m[1] : '', isArchiveReport);
           })
             .catch(error => {
                 contentEl.innerHTML = `

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -109,6 +109,16 @@ def test_report_viewers_include_archive_navigation_affordance():
         assert "location.search" in viewer
 
 
+def test_report_viewers_label_archived_report_metadata():
+    for viewer_path in REPORT_VIEWERS:
+        viewer = viewer_path.read_text()
+
+        assert "renderReportMetadata" in viewer
+        assert "Archived report" in viewer
+        assert "Latest report" in viewer
+        assert "metaEl.textContent = `Last updated:" not in viewer
+
+
 def test_report_archive_route_has_static_index():
     archive = ARCHIVE_INDEX.read_text()
 


### PR DESCRIPTION
## Summary
- Label archived report routes as archived in the styled reader.
- Keep latest report routes labeled with last-updated metadata.

## Validation
- uv run python -B -W error -m pytest tests/test_report_viewer_security.py::test_report_viewers_label_archived_report_metadata -q -p no:cacheprovider
- bash scripts/local_validation.sh
- Browser desktop and mobile report metadata checks