### PR TITLE
Add archive topic counts

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -109,6 +109,13 @@
             border-color: #fca5a5;
             color: #991b1b;
         }
+        .archive-topic-count {
+            color: var(--muted);
+            margin-left: 4px;
+        }
+        .archive-topic-filters button[aria-pressed="true"] .archive-topic-count {
+            color: #991b1b;
+        }
         .archive-clear-filters {
             background: transparent;
             border: 0;
@@ -220,20 +227,34 @@
         let archiveItems = [];
         let activeTopic = '';
 
-        function createArchiveTopicButton(topic, pressed) {
+        function createArchiveTopicButton(topic, total, pressed) {
             const button = document.createElement('button');
             button.type = 'button';
             button.dataset.topic = topic;
             button.setAttribute('aria-pressed', String(pressed));
-            button.textContent = topic || 'All';
+            const label = document.createElement('span');
+            label.textContent = topic || 'All';
+            const count = document.createElement('span');
+            count.className = 'archive-topic-count';
+            count.setAttribute('aria-label', `${total} ${total === 1 ? 'report' : 'reports'}`);
+            count.textContent = String(total);
+            button.append(label, ' ', count);
             return button;
         }
 
         function renderArchiveTopicFilters() {
             const topics = Array.from(new Set(archiveReports.flatMap(report => report.topics)));
+            const topicCounts = new Map();
+            archiveReports.forEach(report => {
+                report.topics.forEach(topic => {
+                    topicCounts.set(topic, (topicCounts.get(topic) || 0) + 1);
+                });
+            });
             const fragment = document.createDocumentFragment();
-            fragment.appendChild(createArchiveTopicButton('', true));
-            topics.forEach(topic => fragment.appendChild(createArchiveTopicButton(topic, false)));
+            fragment.appendChild(createArchiveTopicButton('', archiveReports.length, true));
+            topics.forEach(topic => {
+                fragment.appendChild(createArchiveTopicButton(topic, topicCounts.get(topic) || 0, false));
+            });
             archiveTopicFiltersEl.innerHTML = '';
             archiveTopicFiltersEl.appendChild(fragment);
             archiveTopicButtons = Array.from(archiveTopicFiltersEl.querySelectorAll('button'));

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -144,6 +144,9 @@ def test_report_archive_route_has_static_index():
     assert "const archiveReports = [" in archive
     assert "renderArchiveReports" in archive
     assert "renderArchiveTopicFilters" in archive
+    assert "topicCounts" in archive
+    assert "label.textContent = topic || 'All'" in archive
+    assert "count.textContent = String(total)" in archive
     assert "createElement('article')" in archive
     assert "CVE-2025-5777" in archive
     assert "archiveEmptyEl.hidden = visible !== 0" in archive


### PR DESCRIPTION
## Summary
- Add generated counts to archive topic filters.
- Keep archive search, topic filtering, and clear-filter behavior intact.

## Validation
- uv run python -B -W error -m pytest tests/test_report_viewer_security.py::test_report_archive_route_has_static_index -q -p no:cacheprovider
- bash scripts/local_validation.sh
- Browser desktop and mobile archive interaction checks