### PR TITLE
Add archive summary date

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -254,7 +254,14 @@
             const topics = new Set(archiveReports.flatMap(report => report.topics));
             const reportTotal = archiveReports.length;
             const topicTotal = topics.size;
-            archiveSummaryEl.textContent = `${reportTotal} ${reportTotal === 1 ? 'archived report' : 'archived reports'} · ${topicTotal} ${topicTotal === 1 ? 'tracked topic' : 'tracked topics'}`;
+            const latestReport = archiveReports
+                .slice()
+                .sort((a, b) => b.archivedAt.localeCompare(a.archivedAt))[0];
+            if (!latestReport) {
+                archiveSummaryEl.textContent = 'No archived reports yet';
+                return;
+            }
+            archiveSummaryEl.textContent = `${reportTotal} ${reportTotal === 1 ? 'archived report' : 'archived reports'} · ${topicTotal} ${topicTotal === 1 ? 'tracked topic' : 'tracked topics'} · Latest archive: ${latestReport.archivedLabel}`;
         }
 
         function renderArchiveTopicFilters() {

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -133,6 +133,10 @@ def test_report_archive_route_has_static_index():
     assert "filterArchive" in archive
     assert "renderArchiveSummary" in archive
     assert "archiveSummaryEl.textContent" in archive
+    assert "latestReport.archivedLabel" in archive
+    assert "Latest archive:" in archive
+    assert "if (!latestReport)" in archive
+    assert "No archived reports yet" in archive
     assert "dataset.search" in archive
     assert "archivedAt: '2026-06-23'" in archive
     assert "time.dateTime = report.archivedAt" in archive


### PR DESCRIPTION
## Summary
- Add the latest archived report date to the archive summary.
- Preserve archive topic counts, filtering, and clear-filter behavior.

## Validation
- uv run python -B -W error -m pytest tests/test_report_viewer_security.py::test_report_archive_route_has_static_index -q -p no:cacheprovider
- bash scripts/local_validation.sh
- Browser desktop and mobile archive interaction checks