### PR TITLE
Link latest archive summary

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -261,7 +261,11 @@
                 archiveSummaryEl.textContent = 'No archived reports yet';
                 return;
             }
-            archiveSummaryEl.textContent = `${reportTotal} ${reportTotal === 1 ? 'archived report' : 'archived reports'} · ${topicTotal} ${topicTotal === 1 ? 'tracked topic' : 'tracked topics'} · Latest archive: ${latestReport.archivedLabel}`;
+            archiveSummaryEl.textContent = `${reportTotal} ${reportTotal === 1 ? 'archived report' : 'archived reports'} · ${topicTotal} ${topicTotal === 1 ? 'tracked topic' : 'tracked topics'} · Latest archive: `;
+            const latestArchiveLink = document.createElement('a');
+            latestArchiveLink.href = latestReport.href;
+            latestArchiveLink.textContent = latestReport.archivedLabel;
+            archiveSummaryEl.appendChild(latestArchiveLink);
         }
 
         function renderArchiveTopicFilters() {

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -135,6 +135,8 @@ def test_report_archive_route_has_static_index():
     assert "archiveSummaryEl.textContent" in archive
     assert "latestReport.archivedLabel" in archive
     assert "Latest archive:" in archive
+    assert "latestArchiveLink.href = latestReport.href" in archive
+    assert "latestArchiveLink.textContent = latestReport.archivedLabel" in archive
     assert "if (!latestReport)" in archive
     assert "No archived reports yet" in archive
     assert "dataset.search" in archive


### PR DESCRIPTION
## Summary
- Link the latest archive date in the archive summary to the archived report.
- Keep the empty-archive summary guard and existing filter behavior intact.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_viewer_security.py::test_report_archive_route_has_static_index -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`
- Browser desktop and mobile archive interaction checks