### PR TITLE
Add archive topic chip filters

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -169,9 +169,14 @@
             border: 1px solid #fecaca;
             border-radius: 999px;
             color: #991b1b;
+            cursor: pointer;
+            font: inherit;
             font-size: 0.78rem;
             font-weight: 700;
             padding: 3px 8px;
+        }
+        .archive-tag:hover {
+            background: #fecaca;
         }
         .archive-empty {
             background: var(--panel);
@@ -321,9 +326,11 @@
                 tags.className = 'archive-tags';
                 tags.setAttribute('aria-label', 'Report topics');
                 report.topics.forEach(topic => {
-                    const tag = document.createElement('span');
+                    const tag = document.createElement('button');
                     tag.className = 'archive-tag';
+                    tag.type = 'button';
                     tag.textContent = topic;
+                    tag.addEventListener('click', () => filterArchiveByTopic(topic));
                     tags.appendChild(tag);
                 });
                 article.appendChild(tags);

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -157,6 +157,9 @@ def test_report_archive_route_has_static_index():
     assert "label.textContent = topic || 'All'" in archive
     assert "count.textContent = String(total)" in archive
     assert "createElement('article')" in archive
+    assert "createElement('button')" in archive
+    assert "tag.type = 'button'" in archive
+    assert "filterArchiveByTopic(topic)" in archive
     assert "CVE-2025-5777" in archive
     assert "archiveEmptyEl.hidden = visible !== 0" in archive
 


### PR DESCRIPTION
## Summary
- Make archive card topic chips clickable filter controls.
- Reuse the existing archive topic filter and clear-filter behavior.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_viewer_security.py::test_report_archive_route_has_static_index -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`
- Browser desktop and mobile archive interaction checks