### PR TITLE
Add archive focus states

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -63,6 +63,10 @@
             text-decoration: none;
         }
         a:hover { text-decoration: underline; }
+        .archive-focus-target:focus-visible {
+            outline: 3px solid #2563eb;
+            outline-offset: 3px;
+        }
         .back {
             border: 1px solid var(--border);
             border-radius: 8px;
@@ -243,6 +247,7 @@
         function createArchiveTopicButton(topic, total, pressed) {
             const button = document.createElement('button');
             button.type = 'button';
+            button.classList.add('archive-focus-target');
             button.dataset.topic = topic;
             button.setAttribute('aria-pressed', String(pressed));
             const label = document.createElement('span');
@@ -268,6 +273,7 @@
             }
             archiveSummaryEl.textContent = `${reportTotal} ${reportTotal === 1 ? 'archived report' : 'archived reports'} · ${topicTotal} ${topicTotal === 1 ? 'tracked topic' : 'tracked topics'} · Latest archive: `;
             const latestArchiveLink = document.createElement('a');
+            latestArchiveLink.classList.add('archive-focus-target');
             latestArchiveLink.href = latestReport.href;
             latestArchiveLink.textContent = latestReport.archivedLabel;
             archiveSummaryEl.appendChild(latestArchiveLink);
@@ -304,6 +310,7 @@
 
                 const heading = document.createElement('h2');
                 const link = document.createElement('a');
+                link.classList.add('archive-focus-target');
                 link.href = report.href;
                 link.textContent = report.title;
                 heading.appendChild(link);
@@ -328,6 +335,7 @@
                 report.topics.forEach(topic => {
                     const tag = document.createElement('button');
                     tag.className = 'archive-tag';
+                    tag.classList.add('archive-focus-target');
                     tag.type = 'button';
                     tag.textContent = topic;
                     tag.addEventListener('click', () => filterArchiveByTopic(topic));

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -160,6 +160,10 @@ def test_report_archive_route_has_static_index():
     assert "createElement('button')" in archive
     assert "tag.type = 'button'" in archive
     assert "filterArchiveByTopic(topic)" in archive
+    assert ".archive-focus-target:focus-visible" in archive
+    assert "outline: 3px solid #2563eb" in archive
+    assert "outline-offset: 3px" in archive
+    assert "classList.add('archive-focus-target')" in archive
     assert "CVE-2025-5777" in archive
     assert "archiveEmptyEl.hidden = visible !== 0" in archive
 


### PR DESCRIPTION
## Summary
- Add a shared focus-visible style for archive interactive controls.
- Apply the focus target class to archive links, topic filters, and topic chips.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_viewer_security.py::test_report_archive_route_has_static_index -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`
- Browser desktop and mobile archive focus checks