### PR TITLE
Add archive topic labels

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -163,10 +163,17 @@
         }
         .archive-item p { margin: 0; }
         .archive-tags {
+            align-items: center;
             display: flex;
             flex-wrap: wrap;
             gap: 6px;
             margin-top: 12px;
+        }
+        .archive-tag-label {
+            color: var(--muted);
+            font-size: 0.78rem;
+            font-weight: 700;
+            margin-right: 2px;
         }
         .archive-tag {
             background: #fee2e2;
@@ -332,6 +339,10 @@
                 const tags = document.createElement('div');
                 tags.className = 'archive-tags';
                 tags.setAttribute('aria-label', 'Report topics');
+                const archiveTagLabel = document.createElement('span');
+                archiveTagLabel.className = 'archive-tag-label';
+                archiveTagLabel.textContent = 'Topics';
+                tags.appendChild(archiveTagLabel);
                 report.topics.forEach(topic => {
                     const tag = document.createElement('button');
                     tag.className = 'archive-tag';

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -158,6 +158,8 @@ def test_report_archive_route_has_static_index():
     assert "count.textContent = String(total)" in archive
     assert "createElement('article')" in archive
     assert "createElement('button')" in archive
+    assert "archiveTagLabel.className = 'archive-tag-label'" in archive
+    assert "archiveTagLabel.textContent = 'Topics'" in archive
     assert "tag.type = 'button'" in archive
     assert "filterArchiveByTopic(topic)" in archive
     assert ".archive-focus-target:focus-visible" in archive


### PR DESCRIPTION
## Summary
- Add a visible label for archive card topic chips.
- Keep topic chip clicks on the existing archive topic-filter path.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_viewer_security.py::test_report_archive_route_has_static_index -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`
- Browser desktop and mobile archive label and chip-filter checks
