### PR TITLE
Add report coverage notes

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -398,6 +398,31 @@
         body.dark .uncertainty { background: var(--dark-elev); border-color: #1f2937; }
         body.dark .uncertainty h4 { color: #cbd5e1; }
         body.dark .uncertainty p { color: #e5e7eb; }
+        .coverage-notes {
+            border: 1px solid var(--border-color);
+            background: #ffffff;
+            border-radius: 10px;
+            padding: 12px;
+            margin: 0 0 16px;
+        }
+        .coverage-notes h4 {
+            margin: 0 0 6px;
+            color: var(--text-secondary);
+        }
+        .coverage-notes ul {
+            margin: 0;
+            padding-left: 18px;
+        }
+        .coverage-notes li {
+            color: var(--text-primary);
+            margin: 4px 0;
+        }
+        .coverage-notes strong {
+            color: var(--text-secondary);
+        }
+        body.dark .coverage-notes { background: var(--dark-elev); border-color: #1f2937; }
+        body.dark .coverage-notes h4 { color: #cbd5e1; }
+        body.dark .coverage-notes li { color: #e5e7eb; }
 
         /* Add loading animation */
         .loading {
@@ -500,6 +525,7 @@
                 <div id="summary" class="summary"></div>
                 <div id="provenance" class="provenance" hidden></div>
                 <div id="uncertainty" class="uncertainty" hidden></div>
+                <div id="coverage-notes" class="coverage-notes" hidden></div>
                 <div class="section-filter">
                     <label for="section-filter">Filter report sections</label>
                     <input id="section-filter" type="search" autocomplete="off" placeholder="Search vulnerabilities, products, actors, or techniques" />
@@ -519,6 +545,7 @@
         const summaryEl = document.getElementById('summary');
         const provenanceEl = document.getElementById('provenance');
         const uncertaintyEl = document.getElementById('uncertainty');
+        const coverageNotesEl = document.getElementById('coverage-notes');
         const toggleDarkEl = document.getElementById('toggle-dark');
         const archiveLinkEl = document.getElementById('archive-link');
         const execEl = document.getElementById('exec');
@@ -944,6 +971,42 @@
             `;
         }
 
+        function buildCoverageNote(label, detail) {
+            const item = document.createElement('li');
+            const labelEl = document.createElement('strong');
+            labelEl.textContent = `${label}: `;
+            item.appendChild(labelEl);
+            item.appendChild(document.createTextNode(detail));
+            return item;
+        }
+
+        function renderCoverageNotes() {
+            const sections = buildFilterGroups().length;
+            const sourceEntries = extractSourceAttributionEntries().length;
+            const uncertaintySignals = countUncertaintySignals();
+            if (!sections && !sourceEntries && !uncertaintySignals) {
+                coverageNotesEl.hidden = true;
+                coverageNotesEl.innerHTML = '';
+                return;
+            }
+            const notes = [
+                buildCoverageNote('Section index', `${sections} rendered report sections are included in the page index and section filter.`),
+                buildCoverageNote('Source coverage', sourceEntries
+                    ? `${sourceEntries} source attribution entries are available in the provenance panel.`
+                    : 'No source attribution entries were found in this rendered report.'),
+                buildCoverageNote('Uncertainty coverage', uncertaintySignals
+                    ? `${uncertaintySignals} uncertainty wording signals are surfaced above the report.`
+                    : 'No uncertainty wording signals were detected in this rendered report.'),
+            ];
+            coverageNotesEl.hidden = false;
+            coverageNotesEl.innerHTML = '';
+            const heading = document.createElement('h4');
+            heading.textContent = 'Report Coverage';
+            const list = document.createElement('ul');
+            notes.forEach(note => list.appendChild(note));
+            coverageNotesEl.append(heading, list);
+        }
+
         function buildFilterGroups() {
             const groups = [];
             let currentHeading = null;
@@ -1107,6 +1170,7 @@
                 computeSummary();
                 renderProvenance();
                 renderUncertaintySignals();
+                renderCoverageNotes();
                 filterSections();
                 const m = text.match(/title:\s*Exploitation Intelligence Report\s*-\s*(\d{4}-\d{2}-\d{2})/i);
                 renderReportMetadata(m ? m[1] : '', isArchiveReport);

--- a/index.html
+++ b/index.html
@@ -398,6 +398,31 @@
         body.dark .uncertainty { background: var(--dark-elev); border-color: #1f2937; }
         body.dark .uncertainty h4 { color: #cbd5e1; }
         body.dark .uncertainty p { color: #e5e7eb; }
+        .coverage-notes {
+            border: 1px solid var(--border-color);
+            background: #ffffff;
+            border-radius: 10px;
+            padding: 12px;
+            margin: 0 0 16px;
+        }
+        .coverage-notes h4 {
+            margin: 0 0 6px;
+            color: var(--text-secondary);
+        }
+        .coverage-notes ul {
+            margin: 0;
+            padding-left: 18px;
+        }
+        .coverage-notes li {
+            color: var(--text-primary);
+            margin: 4px 0;
+        }
+        .coverage-notes strong {
+            color: var(--text-secondary);
+        }
+        body.dark .coverage-notes { background: var(--dark-elev); border-color: #1f2937; }
+        body.dark .coverage-notes h4 { color: #cbd5e1; }
+        body.dark .coverage-notes li { color: #e5e7eb; }
 
         /* Add loading animation */
         .loading {
@@ -500,6 +525,7 @@
                 <div id="summary" class="summary"></div>
                 <div id="provenance" class="provenance" hidden></div>
                 <div id="uncertainty" class="uncertainty" hidden></div>
+                <div id="coverage-notes" class="coverage-notes" hidden></div>
                 <div class="section-filter">
                     <label for="section-filter">Filter report sections</label>
                     <input id="section-filter" type="search" autocomplete="off" placeholder="Search vulnerabilities, products, actors, or techniques" />
@@ -519,6 +545,7 @@
         const summaryEl = document.getElementById('summary');
         const provenanceEl = document.getElementById('provenance');
         const uncertaintyEl = document.getElementById('uncertainty');
+        const coverageNotesEl = document.getElementById('coverage-notes');
         const toggleDarkEl = document.getElementById('toggle-dark');
         const archiveLinkEl = document.getElementById('archive-link');
         const execEl = document.getElementById('exec');
@@ -944,6 +971,42 @@
             `;
         }
 
+        function buildCoverageNote(label, detail) {
+            const item = document.createElement('li');
+            const labelEl = document.createElement('strong');
+            labelEl.textContent = `${label}: `;
+            item.appendChild(labelEl);
+            item.appendChild(document.createTextNode(detail));
+            return item;
+        }
+
+        function renderCoverageNotes() {
+            const sections = buildFilterGroups().length;
+            const sourceEntries = extractSourceAttributionEntries().length;
+            const uncertaintySignals = countUncertaintySignals();
+            if (!sections && !sourceEntries && !uncertaintySignals) {
+                coverageNotesEl.hidden = true;
+                coverageNotesEl.innerHTML = '';
+                return;
+            }
+            const notes = [
+                buildCoverageNote('Section index', `${sections} rendered report sections are included in the page index and section filter.`),
+                buildCoverageNote('Source coverage', sourceEntries
+                    ? `${sourceEntries} source attribution entries are available in the provenance panel.`
+                    : 'No source attribution entries were found in this rendered report.'),
+                buildCoverageNote('Uncertainty coverage', uncertaintySignals
+                    ? `${uncertaintySignals} uncertainty wording signals are surfaced above the report.`
+                    : 'No uncertainty wording signals were detected in this rendered report.'),
+            ];
+            coverageNotesEl.hidden = false;
+            coverageNotesEl.innerHTML = '';
+            const heading = document.createElement('h4');
+            heading.textContent = 'Report Coverage';
+            const list = document.createElement('ul');
+            notes.forEach(note => list.appendChild(note));
+            coverageNotesEl.append(heading, list);
+        }
+
         function buildFilterGroups() {
             const groups = [];
             let currentHeading = null;
@@ -1092,6 +1155,7 @@
                 computeSummary();
                 renderProvenance();
                 renderUncertaintySignals();
+                renderCoverageNotes();
                 filterSections();
                 const m = text.match(/title:\s*Exploitation Intelligence Report\s*-\s*(\d{4}-\d{2}-\d{2})/i);
                 renderReportMetadata(m ? m[1] : '', isArchiveReport);

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -211,3 +211,21 @@ def test_report_viewers_include_uncertainty_signal_panel():
         assert "uncertaintyEl.hidden = false" in viewer
         assert "unknown|uncertain|suspected|likely|possible|potential|could" in viewer
         assert "potential, or could" in viewer
+
+
+def test_report_viewers_include_coverage_notes_panel():
+    for viewer_path in REPORT_VIEWERS:
+        viewer = viewer_path.read_text()
+
+        assert 'id="coverage-notes"' in viewer
+        assert "Report Coverage" in viewer
+        assert "renderCoverageNotes" in viewer
+        assert "buildCoverageNote" in viewer
+        assert "coverageNotesEl.hidden = true" in viewer
+        assert "coverageNotesEl.hidden = false" in viewer
+        assert "const sections = buildFilterGroups().length" in viewer
+        assert "extractSourceAttributionEntries().length" in viewer
+        assert "countUncertaintySignals()" in viewer
+        assert "Section index" in viewer
+        assert "Source coverage" in viewer
+        assert "Uncertainty coverage" in viewer


### PR DESCRIPTION
## Summary
- Add a derived coverage notes panel to the report viewer.
- Surface section index, source attribution, and uncertainty coverage from existing rendered report state.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_viewer_security.py::test_report_viewers_include_coverage_notes_panel -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`
- Browser desktop and mobile coverage notes checks
