### PR TITLE
Add archive query state

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -367,7 +367,39 @@
                 .forEach(item => archiveListEl.appendChild(item));
         }
 
-        function filterArchive() {
+        function readArchiveQueryState() {
+            const params = new URLSearchParams(window.location.search);
+            return {
+                query: (params.get('q') || '').trim(),
+                topic: (params.get('topic') || '').trim(),
+            };
+        }
+
+        function writeArchiveQueryState() {
+            const query = archiveFilterEl.value.trim();
+            const params = new URLSearchParams(window.location.search);
+            if (query) {
+                params.set('q', query);
+            } else {
+                params.delete('q');
+            }
+            if (activeTopic) {
+                params.set('topic', activeTopic);
+            } else {
+                params.delete('topic');
+            }
+            const nextSearch = params.toString();
+            const nextUrl = `${window.location.pathname}${nextSearch ? `?${nextSearch}` : ''}${window.location.hash}`;
+            history.replaceState(null, '', nextUrl);
+        }
+
+        function normalizeArchiveTopic(topic) {
+            if (!topic) return '';
+            return archiveReports.some(report => report.topics.includes(topic)) ? topic : '';
+        }
+
+        function filterArchive(options = {}) {
+            const { syncQuery = true } = options;
             const query = archiveFilterEl.value.trim().toLowerCase();
             let visible = 0;
             archiveItems.forEach(item => {
@@ -381,14 +413,21 @@
             archiveCountEl.textContent = `${visible} ${visible === 1 ? 'report' : 'reports'} shown`;
             archiveEmptyEl.hidden = visible !== 0;
             archiveClearFiltersEl.disabled = !query && !activeTopic;
+            if (syncQuery) writeArchiveQueryState();
         }
 
-        function filterArchiveByTopic(topic) {
-            activeTopic = topic;
+        function filterArchiveByTopic(topic, options = {}) {
+            activeTopic = normalizeArchiveTopic(topic);
             archiveTopicButtons.forEach(button => {
                 button.setAttribute('aria-pressed', String(button.dataset.topic === activeTopic));
             });
-            filterArchive();
+            filterArchive(options);
+        }
+
+        function applyArchiveQueryState() {
+            const { query, topic } = readArchiveQueryState();
+            archiveFilterEl.value = query;
+            filterArchiveByTopic(topic, { syncQuery: false });
         }
 
         function clearArchiveFilters() {
@@ -396,13 +435,13 @@
             filterArchiveByTopic('');
         }
 
-        archiveFilterEl.addEventListener('input', filterArchive);
+        archiveFilterEl.addEventListener('input', () => filterArchive());
         archiveClearFiltersEl.addEventListener('click', clearArchiveFilters);
         renderArchiveSummary();
         renderArchiveReports();
         renderArchiveTopicFilters();
         sortNewestFirst();
-        filterArchive();
+        applyArchiveQueryState();
     </script>
 </body>
 </html>

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -170,6 +170,24 @@ def test_report_archive_route_has_static_index():
     assert "archiveEmptyEl.hidden = visible !== 0" in archive
 
 
+def test_report_archive_filter_state_uses_canonical_query_params():
+    archive = ARCHIVE_INDEX.read_text()
+
+    assert "function readArchiveQueryState()" in archive
+    assert "function writeArchiveQueryState()" in archive
+    assert "new URLSearchParams(window.location.search)" in archive
+    assert "params.get('q')" in archive
+    assert "params.get('topic')" in archive
+    assert "params.set('q', query)" in archive
+    assert "params.set('topic', activeTopic)" in archive
+    assert "history.replaceState" in archive
+    assert "readArchiveQueryState()" in archive
+    assert "writeArchiveQueryState()" in archive
+    assert "archiveFilterEl.value = query" in archive
+    assert "filterArchiveByTopic(topic, { syncQuery: false })" in archive
+    assert "archiveFilterEl.addEventListener('input', () => filterArchive())" in archive
+
+
 def test_report_viewers_include_source_provenance_panel():
     for viewer_path in REPORT_VIEWERS:
         viewer = viewer_path.read_text()


### PR DESCRIPTION
## Summary
- Add URL-backed query state for archive search and topic filters.
- Restore filtered archive views from `q` and `topic` params and update the URL as filters change.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_viewer_security.py::test_report_archive_route_has_static_index tests/test_report_viewer_security.py::test_report_archive_filter_state_uses_canonical_query_params -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`
- Browser desktop and mobile archive filter checks
