### PR TITLE
Add archive coverage signals

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -199,6 +199,27 @@
         .archive-action:hover {
             text-decoration: none;
         }
+        .archive-coverage {
+            border-left: 3px solid var(--border);
+            display: grid;
+            gap: 6px;
+            margin: 12px 0 0;
+            padding-left: 10px;
+        }
+        .archive-coverage-heading {
+            color: var(--muted);
+            font-size: 0.78rem;
+            font-weight: 800;
+            text-transform: uppercase;
+        }
+        .archive-coverage-note {
+            color: var(--muted);
+            font-size: 0.86rem;
+            margin: 0;
+        }
+        .archive-coverage-note strong {
+            color: var(--text);
+        }
         .archive-tags {
             align-items: center;
             display: flex;
@@ -283,6 +304,16 @@
                     report: '../index.html?report=reports/index.md',
                     markdown: 'index.md',
                 },
+                coverage: [
+                    {
+                        label: 'Source attribution',
+                        detail: 'No source attribution section is present in this archived markdown.',
+                    },
+                    {
+                        label: 'Archived artifact',
+                        detail: 'Rendered report and source markdown are both available from this archive card.',
+                    },
+                ],
                 search: 'exploitation report citrixbleed netscaler cve-2025-5777 lapdogs soho routers moveit transfer',
             },
         ];
@@ -391,6 +422,27 @@
             return actions;
         }
 
+        function buildArchiveCoverageNotes(report) {
+            const coverage = report.coverage || [];
+            const notes = document.createElement('div');
+            notes.className = 'archive-coverage';
+            if (!coverage.length) return notes;
+            const heading = document.createElement('div');
+            heading.className = 'archive-coverage-heading';
+            heading.textContent = 'Coverage';
+            notes.appendChild(heading);
+            coverage.forEach(({ label, detail }) => {
+                if (!label || !detail) return;
+                const note = document.createElement('p');
+                note.className = 'archive-coverage-note';
+                const strong = document.createElement('strong');
+                strong.textContent = `${label}: `;
+                note.append(strong, detail);
+                notes.appendChild(note);
+            });
+            return notes;
+        }
+
         function renderArchiveReports() {
             const fragment = document.createDocumentFragment();
             archiveReports.forEach(report => {
@@ -420,6 +472,7 @@
                 summary.textContent = report.summary;
                 article.appendChild(summary);
                 article.appendChild(buildArchiveMetricChips(report));
+                article.appendChild(buildArchiveCoverageNotes(report));
                 article.appendChild(buildArchiveActionLinks(report));
 
                 const tags = document.createElement('div');

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -221,6 +221,20 @@ def test_report_archive_entries_render_canonical_action_links():
     assert "article.appendChild(buildArchiveActionLinks(report))" in archive
 
 
+def test_report_archive_entries_render_canonical_coverage_signals():
+    archive = ARCHIVE_INDEX.read_text()
+
+    assert "coverage: [" in archive
+    assert "label: 'Source attribution'" in archive
+    assert "label: 'Archived artifact'" in archive
+    assert "function buildArchiveCoverageNotes(report)" in archive
+    assert "archive-coverage" in archive
+    assert "archive-coverage-note" in archive
+    assert "Coverage" in archive
+    assert "coverage.forEach" in archive
+    assert "article.appendChild(buildArchiveCoverageNotes(report))" in archive
+
+
 def test_report_viewers_include_source_provenance_panel():
     for viewer_path in REPORT_VIEWERS:
         viewer = viewer_path.read_text()


### PR DESCRIPTION
## Summary
- Add a canonical archive coverage contract for report-card coverage notes.
- Render compact coverage notes on archive cards.
- Add a regression guard for archive coverage rendering.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_viewer_security.py::test_report_archive_entries_render_canonical_coverage_signals tests/test_report_viewer_security.py::test_report_archive_entries_render_canonical_action_links tests/test_report_viewer_security.py::test_report_archive_entries_render_canonical_metric_chips tests/test_report_viewer_security.py::test_report_archive_route_has_static_index -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`