### PR TITLE
Add archive artifact rows

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -220,6 +220,38 @@
         .archive-coverage-note strong {
             color: var(--text);
         }
+        .archive-artifacts {
+            margin: 12px 0 0;
+            overflow-x: auto;
+        }
+        .archive-artifact-table {
+            border-collapse: collapse;
+            font-size: 0.84rem;
+            min-width: 320px;
+            width: 100%;
+        }
+        .archive-artifact-table th,
+        .archive-artifact-table td {
+            border-bottom: 1px solid var(--border);
+            padding: 6px 0;
+            text-align: left;
+            vertical-align: top;
+        }
+        .archive-artifact-table th {
+            color: var(--muted);
+            font-size: 0.76rem;
+            font-weight: 800;
+            text-transform: uppercase;
+        }
+        .archive-artifact-table td:first-child {
+            color: var(--text);
+            font-weight: 700;
+            padding-right: 12px;
+            white-space: nowrap;
+        }
+        .archive-artifact-table a {
+            overflow-wrap: anywhere;
+        }
         .archive-tags {
             align-items: center;
             display: flex;
@@ -443,6 +475,46 @@
             return notes;
         }
 
+        const archiveArtifactLabels = {
+            report: 'Rendered report',
+            markdown: 'Source markdown',
+        };
+
+        function buildArchiveArtifactRows(report) {
+            const artifacts = document.createElement('div');
+            artifacts.className = 'archive-artifacts';
+            const table = document.createElement('table');
+            table.className = 'archive-artifact-table';
+            const thead = document.createElement('thead');
+            const header = document.createElement('tr');
+            ['Artifact', 'Path'].forEach(label => {
+                const cell = document.createElement('th');
+                cell.scope = 'col';
+                cell.textContent = label;
+                header.appendChild(cell);
+            });
+            thead.appendChild(header);
+            const tbody = document.createElement('tbody');
+            Object.entries(report.links || {}).forEach(([key, href]) => {
+                const label = archiveArtifactLabels[key];
+                if (!label || !href) return;
+                const row = document.createElement('tr');
+                const labelCell = document.createElement('td');
+                labelCell.textContent = label;
+                const pathCell = document.createElement('td');
+                const link = document.createElement('a');
+                link.classList.add('archive-focus-target');
+                link.href = href;
+                link.textContent = href;
+                pathCell.appendChild(link);
+                row.append(labelCell, pathCell);
+                tbody.appendChild(row);
+            });
+            table.append(thead, tbody);
+            artifacts.appendChild(table);
+            return artifacts;
+        }
+
         function renderArchiveReports() {
             const fragment = document.createDocumentFragment();
             archiveReports.forEach(report => {
@@ -473,6 +545,7 @@
                 article.appendChild(summary);
                 article.appendChild(buildArchiveMetricChips(report));
                 article.appendChild(buildArchiveCoverageNotes(report));
+                article.appendChild(buildArchiveArtifactRows(report));
                 article.appendChild(buildArchiveActionLinks(report));
 
                 const tags = document.createElement('div');

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -235,6 +235,21 @@ def test_report_archive_entries_render_canonical_coverage_signals():
     assert "article.appendChild(buildArchiveCoverageNotes(report))" in archive
 
 
+def test_report_archive_entries_render_artifact_rows_from_links():
+    archive = ARCHIVE_INDEX.read_text()
+
+    assert "function buildArchiveArtifactRows(report)" in archive
+    assert "archive-artifacts" in archive
+    assert "archive-artifact-table" in archive
+    assert "archiveArtifactLabels" in archive
+    assert "Object.entries(report.links || {})" in archive
+    assert "Artifact" in archive
+    assert "Path" in archive
+    assert "Rendered report" in archive
+    assert "Source markdown" in archive
+    assert "article.appendChild(buildArchiveArtifactRows(report))" in archive
+
+
 def test_report_viewers_include_source_provenance_panel():
     for viewer_path in REPORT_VIEWERS:
         viewer = viewer_path.read_text()


### PR DESCRIPTION
## Summary
- Add a compact archive artifact table derived from existing report links.
- Render artifact labels and paths on archive cards.
- Add a regression guard that keeps artifact rows tied to the link contract.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_viewer_security.py::test_report_archive_entries_render_artifact_rows_from_links tests/test_report_viewer_security.py::test_report_archive_entries_render_canonical_coverage_signals tests/test_report_viewer_security.py::test_report_archive_entries_render_canonical_action_links tests/test_report_viewer_security.py::test_report_archive_route_has_static_index -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`