### PR TITLE
Add archive filter summary

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -97,6 +97,12 @@
             font-size: 0.9rem;
             margin-top: 8px;
         }
+        .archive-filter-summary {
+            color: var(--muted);
+            font-size: 0.86rem;
+            line-height: 1.45;
+            margin-top: 6px;
+        }
         .archive-topic-filters {
             display: flex;
             flex-wrap: wrap;
@@ -313,6 +319,7 @@
             <div class="archive-topic-filters" id="archive-topic-filters" aria-label="Filter by report topic"></div>
             <button class="archive-clear-filters" id="archive-clear-filters" type="button" disabled>Clear filters</button>
             <div class="archive-count" id="archive-count">1 report available</div>
+            <div class="archive-filter-summary" id="archive-filter-summary" aria-live="polite">Showing all archived reports.</div>
         </div>
         <section class="archive-list" id="archive-list" aria-label="Available reports"></section>
         <div class="archive-empty" id="archive-empty" hidden>No archived reports match that filter.</div>
@@ -350,6 +357,7 @@
             },
         ];
         const archiveFilterEl = document.getElementById('archive-filter');
+        const archiveFilterSummaryEl = document.getElementById('archive-filter-summary');
         const archiveSummaryEl = document.getElementById('archive-summary');
         const archiveCountEl = document.getElementById('archive-count');
         const archiveEmptyEl = document.getElementById('archive-empty');
@@ -610,6 +618,17 @@
             return archiveReports.some(report => report.topics.includes(topic)) ? topic : '';
         }
 
+        function renderArchiveFilterSummary(query, visible, total) {
+            if (!query && !activeTopic) {
+                archiveFilterSummaryEl.textContent = 'Showing all archived reports.';
+                return;
+            }
+            const filters = [];
+            if (activeTopic) filters.push(`topic ${activeTopic}`);
+            if (query) filters.push(`search "${query}"`);
+            archiveFilterSummaryEl.textContent = `Filtering by ${filters.join(' and ')}. ${visible} of ${total} ${total === 1 ? 'report' : 'reports'} visible.`;
+        }
+
         function filterArchive(options = {}) {
             const { syncQuery = true } = options;
             const query = archiveFilterEl.value.trim().toLowerCase();
@@ -623,6 +642,7 @@
                 if (match) visible += 1;
             });
             archiveCountEl.textContent = `${visible} ${visible === 1 ? 'report' : 'reports'} shown`;
+            renderArchiveFilterSummary(query, visible, archiveItems.length);
             archiveEmptyEl.hidden = visible !== 0;
             archiveClearFiltersEl.disabled = !query && !activeTopic;
             if (syncQuery) writeArchiveQueryState();

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -175,6 +175,16 @@ def test_report_archive_filter_state_uses_canonical_query_params():
 
     assert "function readArchiveQueryState()" in archive
     assert "function writeArchiveQueryState()" in archive
+    assert 'id="archive-filter-summary"' in archive
+    assert (
+        "const archiveFilterSummaryEl = document.getElementById('archive-filter-summary')"
+        in archive
+    )
+    assert "function renderArchiveFilterSummary(query, visible, total)" in archive
+    assert "archiveFilterSummaryEl.textContent" in archive
+    assert "Filtering by" in archive
+    assert "Showing all archived reports." in archive
+    assert "renderArchiveFilterSummary(query, visible, archiveItems.length)" in archive
     assert "new URLSearchParams(window.location.search)" in archive
     assert "params.get('q')" in archive
     assert "params.get('topic')" in archive


### PR DESCRIPTION
## Summary
- Add an accessible archive filter summary derived from the existing query/topic state
- Show default and active filter status in the archive filter panel
- Extend archive guard coverage for the filter summary contract

## Validation
- uv run python -B -W error -m pytest tests/test_report_viewer_security.py::test_report_archive_route_has_static_index tests/test_report_viewer_security.py::test_report_archive_filter_state_uses_canonical_query_params tests/test_report_viewer_security.py::test_report_archive_entries_render_canonical_metric_chips tests/test_report_viewer_security.py::test_report_archive_entries_render_canonical_action_links tests/test_report_viewer_security.py::test_report_archive_entries_render_canonical_coverage_signals tests/test_report_viewer_security.py::test_report_archive_entries_render_artifact_rows_from_links -q -p no:cacheprovider
- bash scripts/local_validation.sh
- Browser desktop and mobile archive checks