### PR TITLE
Add archive section index

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -85,6 +85,24 @@
             font-weight: 700;
             margin: 12px 0 16px;
         }
+        .archive-section-index {
+            align-items: center;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin: -8px 0 18px;
+        }
+        .archive-section-index a {
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            color: var(--text);
+            font-size: 0.84rem;
+            font-weight: 700;
+            padding: 5px 9px;
+        }
+        .archive-section-index a:hover {
+            text-decoration: none;
+        }
         .archive-filter {
             background: var(--panel);
             border: 1px solid var(--border);
@@ -313,7 +331,11 @@
             </div>
             <a class="back" href="../index.html">Latest report</a>
         </header>
-        <div class="archive-filter">
+        <nav class="archive-section-index" aria-label="Archive sections">
+            <a class="archive-focus-target" href="#archive-filter-panel">Filter</a>
+            <a class="archive-focus-target" href="#archive-list">Reports</a>
+        </nav>
+        <div class="archive-filter" id="archive-filter-panel">
             <label for="archive-filter">Filter archived reports</label>
             <input id="archive-filter" type="search" autocomplete="off" placeholder="Search CVEs, vendors, products, or campaigns" />
             <div class="archive-topic-filters" id="archive-topic-filters" aria-label="Filter by report topic"></div>

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -198,6 +198,21 @@ def test_report_archive_filter_state_uses_canonical_query_params():
     assert "archiveFilterEl.addEventListener('input', () => filterArchive())" in archive
 
 
+def test_report_archive_exposes_static_section_index():
+    archive = ARCHIVE_INDEX.read_text()
+
+    assert 'class="archive-section-index"' in archive
+    assert 'aria-label="Archive sections"' in archive
+    assert 'href="#archive-filter-panel"' in archive
+    assert 'href="#archive-list"' in archive
+    assert 'id="archive-filter-panel"' in archive
+    assert 'id="archive-list"' in archive
+    assert "Filter" in archive
+    assert "Reports" in archive
+    assert ".archive-section-index" in archive
+    assert ".archive-section-index a" in archive
+
+
 def test_report_archive_entries_render_canonical_metric_chips():
     archive = ARCHIVE_INDEX.read_text()
 


### PR DESCRIPTION
## Summary
- Add a compact in-page section index to the report archive
- Link the index to the archive filter panel and report list anchors
- Add guard coverage for the archive section index contract

## Validation
- uv run python -B -W error -m pytest tests/test_report_viewer_security.py::test_report_archive_route_has_static_index tests/test_report_viewer_security.py::test_report_archive_filter_state_uses_canonical_query_params tests/test_report_viewer_security.py::test_report_archive_exposes_static_section_index tests/test_report_viewer_security.py::test_report_archive_entries_render_canonical_action_links -q -p no:cacheprovider
- bash scripts/local_validation.sh
- Browser desktop and mobile archive checks