### PR TITLE
Add report reading index

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -333,6 +333,36 @@
         .section-filter-hidden { display: none !important; }
         body.dark .section-filter { background: var(--dark-elev); border-color: #1f2937; }
         body.dark .section-filter input { background: #0b1220; border-color: #1f2937; color: #e5e7eb; }
+        .reading-index {
+            align-items: center;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin: 0 0 16px;
+        }
+        .reading-index a {
+            border: 1px solid var(--border-color);
+            border-radius: 8px;
+            color: var(--text-primary);
+            font-size: 0.84rem;
+            font-weight: 700;
+            padding: 5px 9px;
+            text-decoration: none;
+        }
+        .reading-index a:hover {
+            background: #f1f5f9;
+        }
+        #provenance, #coverage-notes, #section-filter-panel, #content {
+            scroll-margin-top: 80px;
+        }
+        body.dark .reading-index a {
+            background: #111827;
+            border-color: #1f2937;
+            color: #e5e7eb;
+        }
+        body.dark .reading-index a:hover {
+            background: #0b1220;
+        }
 
         .provenance {
             border: 1px solid var(--border-color);
@@ -523,10 +553,16 @@
             <main>
                 <div class="meta" id="meta"></div>
                 <div id="summary" class="summary"></div>
+                <nav class="reading-index" aria-label="Report reading sections">
+                    <a id="reading-index-sources" hidden href="#provenance">Sources</a>
+                    <a href="#coverage-notes">Coverage</a>
+                    <a href="#section-filter-panel">Filter</a>
+                    <a href="#content">Report</a>
+                </nav>
                 <div id="provenance" class="provenance" hidden></div>
                 <div id="uncertainty" class="uncertainty" hidden></div>
                 <div id="coverage-notes" class="coverage-notes" hidden></div>
-                <div class="section-filter">
+                <div class="section-filter" id="section-filter-panel">
                     <label for="section-filter">Filter report sections</label>
                     <input id="section-filter" type="search" autocomplete="off" placeholder="Search vulnerabilities, products, actors, or techniques" />
                     <div class="filter-meta" id="section-filter-count"></div>
@@ -546,6 +582,7 @@
         const provenanceEl = document.getElementById('provenance');
         const uncertaintyEl = document.getElementById('uncertainty');
         const coverageNotesEl = document.getElementById('coverage-notes');
+        const readingIndexSourceEl = document.getElementById('reading-index-sources');
         const toggleDarkEl = document.getElementById('toggle-dark');
         const archiveLinkEl = document.getElementById('archive-link');
         const execEl = document.getElementById('exec');
@@ -940,6 +977,10 @@
             provenanceEl.appendChild(renderSourcePreview(sourceEntries));
         }
 
+        function syncReadingIndex() {
+            readingIndexSourceEl.hidden = provenanceEl.hidden;
+        }
+
         function getVisibleReportText() {
             const textRoots = [execEl, contentEl];
             return textRoots.map(root => {
@@ -1171,6 +1212,7 @@
                 renderProvenance();
                 renderUncertaintySignals();
                 renderCoverageNotes();
+                syncReadingIndex();
                 filterSections();
                 const m = text.match(/title:\s*Exploitation Intelligence Report\s*-\s*(\d{4}-\d{2}-\d{2})/i);
                 renderReportMetadata(m ? m[1] : '', isArchiveReport);

--- a/index.html
+++ b/index.html
@@ -333,6 +333,36 @@
         .section-filter-hidden { display: none !important; }
         body.dark .section-filter { background: var(--dark-elev); border-color: #1f2937; }
         body.dark .section-filter input { background: #0b1220; border-color: #1f2937; color: #e5e7eb; }
+        .reading-index {
+            align-items: center;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin: 0 0 16px;
+        }
+        .reading-index a {
+            border: 1px solid var(--border-color);
+            border-radius: 8px;
+            color: var(--text-primary);
+            font-size: 0.84rem;
+            font-weight: 700;
+            padding: 5px 9px;
+            text-decoration: none;
+        }
+        .reading-index a:hover {
+            background: #f1f5f9;
+        }
+        #provenance, #coverage-notes, #section-filter-panel, #content {
+            scroll-margin-top: 80px;
+        }
+        body.dark .reading-index a {
+            background: #111827;
+            border-color: #1f2937;
+            color: #e5e7eb;
+        }
+        body.dark .reading-index a:hover {
+            background: #0b1220;
+        }
 
         .provenance {
             border: 1px solid var(--border-color);
@@ -523,10 +553,16 @@
             <main>
                 <div class="meta" id="meta"></div>
                 <div id="summary" class="summary"></div>
+                <nav class="reading-index" aria-label="Report reading sections">
+                    <a id="reading-index-sources" hidden href="#provenance">Sources</a>
+                    <a href="#coverage-notes">Coverage</a>
+                    <a href="#section-filter-panel">Filter</a>
+                    <a href="#content">Report</a>
+                </nav>
                 <div id="provenance" class="provenance" hidden></div>
                 <div id="uncertainty" class="uncertainty" hidden></div>
                 <div id="coverage-notes" class="coverage-notes" hidden></div>
-                <div class="section-filter">
+                <div class="section-filter" id="section-filter-panel">
                     <label for="section-filter">Filter report sections</label>
                     <input id="section-filter" type="search" autocomplete="off" placeholder="Search vulnerabilities, products, actors, or techniques" />
                     <div class="filter-meta" id="section-filter-count"></div>
@@ -546,6 +582,7 @@
         const provenanceEl = document.getElementById('provenance');
         const uncertaintyEl = document.getElementById('uncertainty');
         const coverageNotesEl = document.getElementById('coverage-notes');
+        const readingIndexSourceEl = document.getElementById('reading-index-sources');
         const toggleDarkEl = document.getElementById('toggle-dark');
         const archiveLinkEl = document.getElementById('archive-link');
         const execEl = document.getElementById('exec');
@@ -940,6 +977,10 @@
             provenanceEl.appendChild(renderSourcePreview(sourceEntries));
         }
 
+        function syncReadingIndex() {
+            readingIndexSourceEl.hidden = provenanceEl.hidden;
+        }
+
         function getVisibleReportText() {
             const textRoots = [execEl, contentEl];
             return textRoots.map(root => {
@@ -1156,6 +1197,7 @@
                 renderProvenance();
                 renderUncertaintySignals();
                 renderCoverageNotes();
+                syncReadingIndex();
                 filterSections();
                 const m = text.match(/title:\s*Exploitation Intelligence Report\s*-\s*(\d{4}-\d{2}-\d{2})/i);
                 renderReportMetadata(m ? m[1] : '', isArchiveReport);

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -80,6 +80,38 @@ def test_report_viewers_include_section_filter_controls():
         assert "sectionFilterEl.addEventListener('input', filterSections)" in viewer
 
 
+def test_report_viewers_expose_static_reading_index():
+    for viewer_path in REPORT_VIEWERS:
+        viewer = viewer_path.read_text()
+
+        assert 'class="reading-index"' in viewer
+        assert 'aria-label="Report reading sections"' in viewer
+        assert 'id="reading-index-sources"' in viewer
+        assert 'id="reading-index-sources" hidden href="#provenance"' in viewer
+        assert 'href="#provenance"' in viewer
+        assert 'href="#coverage-notes"' in viewer
+        assert 'href="#section-filter-panel"' in viewer
+        assert 'href="#content"' in viewer
+        assert 'id="section-filter-panel"' in viewer
+        assert 'id="provenance"' in viewer
+        assert 'id="coverage-notes"' in viewer
+        assert "#provenance, #coverage-notes, #section-filter-panel, #content" in viewer
+        assert "scroll-margin-top: 80px" in viewer
+        assert (
+            "const readingIndexSourceEl = document.getElementById('reading-index-sources')"
+            in viewer
+        )
+        assert "function syncReadingIndex()" in viewer
+        assert "readingIndexSourceEl.hidden = provenanceEl.hidden" in viewer
+        assert "syncReadingIndex()" in viewer
+        assert ".reading-index" in viewer
+        assert ".reading-index a" in viewer
+        assert "Sources" in viewer
+        assert "Coverage" in viewer
+        assert "Filter" in viewer
+        assert "Report" in viewer
+
+
 def test_report_viewers_include_archive_navigation_affordance():
     for viewer_path in REPORT_VIEWERS:
         viewer = viewer_path.read_text()


### PR DESCRIPTION
## Summary
- Add a compact reading index to the report viewer
- Link the index to sources, coverage, section filtering, and report content anchors
- Add guard coverage across both static viewer copies

## Validation
- uv run python -B -W error -m pytest tests/test_report_viewer_security.py::test_report_viewers_expose_static_reading_index tests/test_report_viewer_security.py::test_report_viewers_include_section_filter_controls tests/test_report_viewer_security.py::test_report_viewers_include_source_provenance_panel tests/test_report_viewer_security.py::test_report_viewers_include_coverage_notes_panel -q -p no:cacheprovider
- bash scripts/local_validation.sh
- Browser desktop and mobile report viewer checks