### PR TITLE
Add archive results region

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -79,6 +79,12 @@
             gap: 12px;
             margin-top: 16px;
         }
+        .archive-results {
+            margin-top: 16px;
+        }
+        .archive-results .archive-list {
+            margin-top: 0;
+        }
         .archive-summary {
             color: var(--muted);
             font-size: 0.95rem;
@@ -348,7 +354,7 @@
         </header>
         <nav class="archive-section-index" aria-label="Archive sections">
             <a class="archive-focus-target" href="#archive-filter-panel">Filter</a>
-            <a class="archive-focus-target" href="#archive-list">Reports</a>
+            <a class="archive-focus-target" href="#archive-results">Reports</a>
         </nav>
         <div class="archive-filter" id="archive-filter-panel">
             <label for="archive-filter">Filter archived reports</label>
@@ -358,11 +364,13 @@
             <div class="archive-count" id="archive-count">1 report available</div>
             <div class="archive-filter-summary" id="archive-filter-summary" aria-live="polite">Showing all archived reports.</div>
         </div>
-        <section class="archive-list" id="archive-list" aria-label="Available reports"></section>
-        <div class="archive-empty" id="archive-empty" hidden>
-            <p>No archived reports match that filter.</p>
-            <button class="archive-empty-clear archive-focus-target" id="archive-empty-clear" type="button">Clear filters</button>
-        </div>
+        <section class="archive-results" id="archive-results" aria-label="Available reports">
+            <div class="archive-list" id="archive-list"></div>
+            <div class="archive-empty" id="archive-empty" hidden>
+                <p>No archived reports match that filter.</p>
+                <button class="archive-empty-clear archive-focus-target" id="archive-empty-clear" type="button">Clear filters</button>
+            </div>
+        </section>
     </main>
     <script>
         const archiveReports = [

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -161,7 +161,11 @@ def test_report_archive_route_has_static_index():
     assert 'id="archive-filter"' in archive
     assert 'id="archive-summary"' in archive
     assert 'id="archive-count"' in archive
+    assert 'href="#archive-results"' in archive
+    assert 'class="archive-results" id="archive-results"' in archive
     assert 'id="archive-empty"' in archive
+    assert archive.index('id="archive-results"') < archive.index('id="archive-empty"')
+    assert archive.index('id="archive-results"') < archive.index('id="archive-list"')
     assert "filterArchive" in archive
     assert "renderArchiveSummary" in archive
     assert "archiveSummaryEl.textContent" in archive
@@ -241,8 +245,9 @@ def test_report_archive_exposes_static_section_index():
     assert 'class="archive-section-index"' in archive
     assert 'aria-label="Archive sections"' in archive
     assert 'href="#archive-filter-panel"' in archive
-    assert 'href="#archive-list"' in archive
+    assert 'href="#archive-results"' in archive
     assert 'id="archive-filter-panel"' in archive
+    assert 'id="archive-results"' in archive
     assert 'id="archive-list"' in archive
     assert "Filter" in archive
     assert "Reports" in archive


### PR DESCRIPTION
## Summary
- Point the archive section index at a shared results region.
- Keep the report list and empty-state feedback under the same results target.
- Add static guards for the archive results-region contract.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_viewer_security.py::test_report_archive_route_has_static_index tests/test_report_viewer_security.py::test_report_archive_exposes_static_section_index -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`