### PR TITLE
Add report filter empty-state action

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -330,6 +330,21 @@
             margin: 12px 0;
             text-align: center;
         }
+        .section-filter-empty p {
+            margin: 0;
+        }
+        .section-filter-empty button {
+            background: var(--text-primary);
+            border: 1px solid var(--text-primary);
+            border-radius: 8px;
+            color: #ffffff;
+            cursor: pointer;
+            font: inherit;
+            font-size: 0.86rem;
+            font-weight: 600;
+            margin-top: 10px;
+            padding: 6px 10px;
+        }
         .section-filter-hidden { display: none !important; }
         body.dark .section-filter { background: var(--dark-elev); border-color: #1f2937; }
         body.dark .section-filter input { background: #0b1220; border-color: #1f2937; color: #e5e7eb; }
@@ -567,7 +582,10 @@
                     <input id="section-filter" type="search" autocomplete="off" placeholder="Search vulnerabilities, products, actors, or techniques" />
                     <div class="filter-meta" id="section-filter-count"></div>
                 </div>
-                <div class="section-filter-empty" id="section-filter-empty">No matching report sections.</div>
+                <div class="section-filter-empty" id="section-filter-empty">
+                    <p>No matching report sections.</p>
+                    <button id="section-filter-clear-empty" type="button">Clear filter</button>
+                </div>
                 <div id="exec" class="exec"></div>
                 <div id="content" class="markdown-body"></div>
             </main>
@@ -589,6 +607,7 @@
         const sectionFilterEl = document.getElementById('section-filter');
         const sectionFilterCountEl = document.getElementById('section-filter-count');
         const sectionFilterEmptyEl = document.getElementById('section-filter-empty');
+        const sectionFilterClearEmptyEl = document.getElementById('section-filter-clear-empty');
 
         // Initial UI state
         contentEl.innerHTML = '<div class="loading">Loading exploitation report...</div>';
@@ -1232,6 +1251,11 @@
             localStorage.setItem('sentryinsight:theme', mode);
         });
         sectionFilterEl.addEventListener('input', filterSections);
+        sectionFilterClearEmptyEl.addEventListener('click', () => {
+            sectionFilterEl.value = '';
+            filterSections();
+            sectionFilterEl.focus();
+        });
         wireShortcuts();
 
         // Copy heading link via anchor click

--- a/index.html
+++ b/index.html
@@ -330,6 +330,21 @@
             margin: 12px 0;
             text-align: center;
         }
+        .section-filter-empty p {
+            margin: 0;
+        }
+        .section-filter-empty button {
+            background: var(--text-primary);
+            border: 1px solid var(--text-primary);
+            border-radius: 8px;
+            color: #ffffff;
+            cursor: pointer;
+            font: inherit;
+            font-size: 0.86rem;
+            font-weight: 600;
+            margin-top: 10px;
+            padding: 6px 10px;
+        }
         .section-filter-hidden { display: none !important; }
         body.dark .section-filter { background: var(--dark-elev); border-color: #1f2937; }
         body.dark .section-filter input { background: #0b1220; border-color: #1f2937; color: #e5e7eb; }
@@ -567,7 +582,10 @@
                     <input id="section-filter" type="search" autocomplete="off" placeholder="Search vulnerabilities, products, actors, or techniques" />
                     <div class="filter-meta" id="section-filter-count"></div>
                 </div>
-                <div class="section-filter-empty" id="section-filter-empty">No matching report sections.</div>
+                <div class="section-filter-empty" id="section-filter-empty">
+                    <p>No matching report sections.</p>
+                    <button id="section-filter-clear-empty" type="button">Clear filter</button>
+                </div>
                 <div id="exec" class="exec"></div>
                 <div id="content" class="markdown-body"></div>
             </main>
@@ -589,6 +607,7 @@
         const sectionFilterEl = document.getElementById('section-filter');
         const sectionFilterCountEl = document.getElementById('section-filter-count');
         const sectionFilterEmptyEl = document.getElementById('section-filter-empty');
+        const sectionFilterClearEmptyEl = document.getElementById('section-filter-clear-empty');
 
         // Initial UI state
         contentEl.innerHTML = '<div class="loading">Loading exploitation report...</div>';
@@ -1217,6 +1236,11 @@
             localStorage.setItem('sentryinsight:theme', mode);
         });
         sectionFilterEl.addEventListener('input', filterSections);
+        sectionFilterClearEmptyEl.addEventListener('click', () => {
+            sectionFilterEl.value = '';
+            filterSections();
+            sectionFilterEl.focus();
+        });
         wireShortcuts();
 
         // Copy heading link via anchor click

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -68,6 +68,7 @@ def test_report_viewers_include_section_filter_controls():
         assert 'id="section-filter"' in viewer
         assert 'id="section-filter-count"' in viewer
         assert 'id="section-filter-empty"' in viewer
+        assert 'id="section-filter-clear-empty"' in viewer
         assert "filterSections" in viewer
         assert "buildFilterGroups" in viewer
         assert "flushDirectGroup" in viewer
@@ -78,6 +79,9 @@ def test_report_viewers_include_section_filter_controls():
         assert "contentEl.querySelectorAll('.section-collapsible')" in viewer
         assert "section-filter-hidden" in viewer
         assert "sectionFilterEl.addEventListener('input', filterSections)" in viewer
+        assert "sectionFilterClearEmptyEl.addEventListener('click'" in viewer
+        assert "sectionFilterEl.value = ''" in viewer
+        assert "sectionFilterEl.focus()" in viewer
 
 
 def test_report_viewers_expose_static_reading_index():


### PR DESCRIPTION
## Summary
- Add a clear action to the report section filter empty state.
- Route the action through the existing section filter reset path.
- Add static guards for the empty-state control wiring.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_viewer_security.py::test_report_viewers_include_section_filter_controls -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`