### PR TITLE
Add report results region

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -367,7 +367,10 @@
         .reading-index a:hover {
             background: #f1f5f9;
         }
-        #provenance, #coverage-notes, #section-filter-panel, #content {
+        .report-results {
+            min-width: 0;
+        }
+        #provenance, #coverage-notes, #section-filter-panel, #report-results, #content {
             scroll-margin-top: 80px;
         }
         body.dark .reading-index a {
@@ -572,7 +575,7 @@
                     <a id="reading-index-sources" hidden href="#provenance">Sources</a>
                     <a href="#coverage-notes">Coverage</a>
                     <a href="#section-filter-panel">Filter</a>
-                    <a href="#content">Report</a>
+                    <a href="#report-results">Report</a>
                 </nav>
                 <div id="provenance" class="provenance" hidden></div>
                 <div id="uncertainty" class="uncertainty" hidden></div>
@@ -582,12 +585,14 @@
                     <input id="section-filter" type="search" autocomplete="off" placeholder="Search vulnerabilities, products, actors, or techniques" />
                     <div class="filter-meta" id="section-filter-count"></div>
                 </div>
-                <div class="section-filter-empty" id="section-filter-empty">
-                    <p>No matching report sections.</p>
-                    <button id="section-filter-clear-empty" type="button">Clear filter</button>
-                </div>
-                <div id="exec" class="exec"></div>
-                <div id="content" class="markdown-body"></div>
+                <section class="report-results" id="report-results" aria-label="Report sections">
+                    <div class="section-filter-empty" id="section-filter-empty">
+                        <p>No matching report sections.</p>
+                        <button id="section-filter-clear-empty" type="button">Clear filter</button>
+                    </div>
+                    <div id="exec" class="exec"></div>
+                    <div id="content" class="markdown-body"></div>
+                </section>
             </main>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -367,7 +367,10 @@
         .reading-index a:hover {
             background: #f1f5f9;
         }
-        #provenance, #coverage-notes, #section-filter-panel, #content {
+        .report-results {
+            min-width: 0;
+        }
+        #provenance, #coverage-notes, #section-filter-panel, #report-results, #content {
             scroll-margin-top: 80px;
         }
         body.dark .reading-index a {
@@ -572,7 +575,7 @@
                     <a id="reading-index-sources" hidden href="#provenance">Sources</a>
                     <a href="#coverage-notes">Coverage</a>
                     <a href="#section-filter-panel">Filter</a>
-                    <a href="#content">Report</a>
+                    <a href="#report-results">Report</a>
                 </nav>
                 <div id="provenance" class="provenance" hidden></div>
                 <div id="uncertainty" class="uncertainty" hidden></div>
@@ -582,12 +585,14 @@
                     <input id="section-filter" type="search" autocomplete="off" placeholder="Search vulnerabilities, products, actors, or techniques" />
                     <div class="filter-meta" id="section-filter-count"></div>
                 </div>
-                <div class="section-filter-empty" id="section-filter-empty">
-                    <p>No matching report sections.</p>
-                    <button id="section-filter-clear-empty" type="button">Clear filter</button>
-                </div>
-                <div id="exec" class="exec"></div>
-                <div id="content" class="markdown-body"></div>
+                <section class="report-results" id="report-results" aria-label="Report sections">
+                    <div class="section-filter-empty" id="section-filter-empty">
+                        <p>No matching report sections.</p>
+                        <button id="section-filter-clear-empty" type="button">Clear filter</button>
+                    </div>
+                    <div id="exec" class="exec"></div>
+                    <div id="content" class="markdown-body"></div>
+                </section>
             </main>
         </div>
     </div>

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -95,11 +95,21 @@ def test_report_viewers_expose_static_reading_index():
         assert 'href="#provenance"' in viewer
         assert 'href="#coverage-notes"' in viewer
         assert 'href="#section-filter-panel"' in viewer
-        assert 'href="#content"' in viewer
+        assert 'href="#report-results"' in viewer
         assert 'id="section-filter-panel"' in viewer
+        assert 'id="report-results"' in viewer
+        assert 'aria-label="Report sections"' in viewer
+        assert 'id="content"' in viewer
+        assert viewer.index('id="report-results"') < viewer.index(
+            'id="section-filter-empty"'
+        )
+        assert viewer.index('id="report-results"') < viewer.index('id="content"')
         assert 'id="provenance"' in viewer
         assert 'id="coverage-notes"' in viewer
-        assert "#provenance, #coverage-notes, #section-filter-panel, #content" in viewer
+        assert (
+            "#provenance, #coverage-notes, #section-filter-panel, #report-results, #content"
+            in viewer
+        )
         assert "scroll-margin-top: 80px" in viewer
         assert (
             "const readingIndexSourceEl = document.getElementById('reading-index-sources')"


### PR DESCRIPTION
## Summary
- Point the report reading index at a shared report results region.
- Keep the report body, executive summary, and filter empty-state feedback under the same target.
- Add static guards for the results-region contract.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_viewer_security.py::test_report_viewers_expose_static_reading_index -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`