### PR TITLE
Add uncertainty index link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -370,7 +370,7 @@
         .report-results {
             min-width: 0;
         }
-        #provenance, #coverage-notes, #section-filter-panel, #report-results, #content {
+        #provenance, #uncertainty, #coverage-notes, #section-filter-panel, #report-results, #content {
             scroll-margin-top: 80px;
         }
         body.dark .reading-index a {
@@ -573,6 +573,7 @@
                 <div id="summary" class="summary"></div>
                 <nav class="reading-index" aria-label="Report reading sections">
                     <a id="reading-index-sources" hidden href="#provenance">Sources</a>
+                    <a id="reading-index-uncertainty" hidden href="#uncertainty">Uncertainty</a>
                     <a href="#coverage-notes">Coverage</a>
                     <a href="#section-filter-panel">Filter</a>
                     <a href="#report-results">Report</a>
@@ -606,6 +607,7 @@
         const uncertaintyEl = document.getElementById('uncertainty');
         const coverageNotesEl = document.getElementById('coverage-notes');
         const readingIndexSourceEl = document.getElementById('reading-index-sources');
+        const readingIndexUncertaintyEl = document.getElementById('reading-index-uncertainty');
         const toggleDarkEl = document.getElementById('toggle-dark');
         const archiveLinkEl = document.getElementById('archive-link');
         const execEl = document.getElementById('exec');
@@ -1003,6 +1005,7 @@
 
         function syncReadingIndex() {
             readingIndexSourceEl.hidden = provenanceEl.hidden;
+            readingIndexUncertaintyEl.hidden = uncertaintyEl.hidden;
         }
 
         function getVisibleReportText() {

--- a/index.html
+++ b/index.html
@@ -370,7 +370,7 @@
         .report-results {
             min-width: 0;
         }
-        #provenance, #coverage-notes, #section-filter-panel, #report-results, #content {
+        #provenance, #uncertainty, #coverage-notes, #section-filter-panel, #report-results, #content {
             scroll-margin-top: 80px;
         }
         body.dark .reading-index a {
@@ -573,6 +573,7 @@
                 <div id="summary" class="summary"></div>
                 <nav class="reading-index" aria-label="Report reading sections">
                     <a id="reading-index-sources" hidden href="#provenance">Sources</a>
+                    <a id="reading-index-uncertainty" hidden href="#uncertainty">Uncertainty</a>
                     <a href="#coverage-notes">Coverage</a>
                     <a href="#section-filter-panel">Filter</a>
                     <a href="#report-results">Report</a>
@@ -606,6 +607,7 @@
         const uncertaintyEl = document.getElementById('uncertainty');
         const coverageNotesEl = document.getElementById('coverage-notes');
         const readingIndexSourceEl = document.getElementById('reading-index-sources');
+        const readingIndexUncertaintyEl = document.getElementById('reading-index-uncertainty');
         const toggleDarkEl = document.getElementById('toggle-dark');
         const archiveLinkEl = document.getElementById('archive-link');
         const execEl = document.getElementById('exec');
@@ -1003,6 +1005,7 @@
 
         function syncReadingIndex() {
             readingIndexSourceEl.hidden = provenanceEl.hidden;
+            readingIndexUncertaintyEl.hidden = uncertaintyEl.hidden;
         }
 
         function getVisibleReportText() {

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -92,7 +92,9 @@ def test_report_viewers_expose_static_reading_index():
         assert 'aria-label="Report reading sections"' in viewer
         assert 'id="reading-index-sources"' in viewer
         assert 'id="reading-index-sources" hidden href="#provenance"' in viewer
+        assert 'id="reading-index-uncertainty" hidden href="#uncertainty"' in viewer
         assert 'href="#provenance"' in viewer
+        assert 'href="#uncertainty"' in viewer
         assert 'href="#coverage-notes"' in viewer
         assert 'href="#section-filter-panel"' in viewer
         assert 'href="#report-results"' in viewer
@@ -105,9 +107,10 @@ def test_report_viewers_expose_static_reading_index():
         )
         assert viewer.index('id="report-results"') < viewer.index('id="content"')
         assert 'id="provenance"' in viewer
+        assert 'id="uncertainty"' in viewer
         assert 'id="coverage-notes"' in viewer
         assert (
-            "#provenance, #coverage-notes, #section-filter-panel, #report-results, #content"
+            "#provenance, #uncertainty, #coverage-notes, #section-filter-panel, #report-results, #content"
             in viewer
         )
         assert "scroll-margin-top: 80px" in viewer
@@ -115,12 +118,18 @@ def test_report_viewers_expose_static_reading_index():
             "const readingIndexSourceEl = document.getElementById('reading-index-sources')"
             in viewer
         )
+        assert (
+            "const readingIndexUncertaintyEl = document.getElementById('reading-index-uncertainty')"
+            in viewer
+        )
         assert "function syncReadingIndex()" in viewer
         assert "readingIndexSourceEl.hidden = provenanceEl.hidden" in viewer
+        assert "readingIndexUncertaintyEl.hidden = uncertaintyEl.hidden" in viewer
         assert "syncReadingIndex()" in viewer
         assert ".reading-index" in viewer
         assert ".reading-index a" in viewer
         assert "Sources" in viewer
+        assert "Uncertainty" in viewer
         assert "Coverage" in viewer
         assert "Filter" in viewer
         assert "Report" in viewer


### PR DESCRIPTION
## Summary
- Add a conditional reading-index link for the uncertainty panel.
- Keep the link visibility synced with the existing uncertainty panel state.
- Add static guards for the reading-index target and scroll offset.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_viewer_security.py::test_report_viewers_expose_static_reading_index -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`