### PR TITLE
Add report markdown action link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -558,6 +558,7 @@
             </div>
             <div class="spacer"></div>
             <div class="toolbar">
+                <a id="markdown-link" class="btn" href="index.md">Markdown</a>
                 <a id="archive-link" class="btn" href="reports/" hidden>Archive</a>
                 <button id="toggle-dark" class="btn" title="Toggle theme">Theme</button>
             </div>
@@ -609,6 +610,7 @@
         const readingIndexSourceEl = document.getElementById('reading-index-sources');
         const readingIndexUncertaintyEl = document.getElementById('reading-index-uncertainty');
         const toggleDarkEl = document.getElementById('toggle-dark');
+        const markdownLinkEl = document.getElementById('markdown-link');
         const archiveLinkEl = document.getElementById('archive-link');
         const execEl = document.getElementById('exec');
         const sectionFilterEl = document.getElementById('section-filter');
@@ -1174,6 +1176,7 @@
         let markdownCache = '';
         const reportPath = resolveReportPath();
         const isArchiveReport = reportPath !== 'index.md';
+        markdownLinkEl.href = reportPath;
         Promise.all([configPromise])
           .then(() => fetch(reportPath + '?v=' + Date.now(), { cache: 'no-store' }))
           .then(response => response.text())

--- a/index.html
+++ b/index.html
@@ -558,6 +558,7 @@
             </div>
             <div class="spacer"></div>
             <div class="toolbar">
+                <a id="markdown-link" class="btn" href="index.md">Markdown</a>
                 <a id="archive-link" class="btn" href="reports/" hidden>Archive</a>
                 <button id="toggle-dark" class="btn" title="Toggle theme">Theme</button>
             </div>
@@ -609,6 +610,7 @@
         const readingIndexSourceEl = document.getElementById('reading-index-sources');
         const readingIndexUncertaintyEl = document.getElementById('reading-index-uncertainty');
         const toggleDarkEl = document.getElementById('toggle-dark');
+        const markdownLinkEl = document.getElementById('markdown-link');
         const archiveLinkEl = document.getElementById('archive-link');
         const execEl = document.getElementById('exec');
         const sectionFilterEl = document.getElementById('section-filter');
@@ -1174,6 +1176,7 @@
         let markdownCache = '';
         const reportPath = resolveReportPath();
         const isArchiveReport = reportPath !== 'index.md';
+        markdownLinkEl.href = reportPath;
         Promise.all([configPromise])
           .then(() => fetch(reportPath + '?v=' + Date.now(), { cache: 'no-store' }))
           .then(response => response.text())

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -164,6 +164,23 @@ def test_report_viewers_include_archive_navigation_affordance():
         assert "location.search" in viewer
 
 
+def test_report_viewers_expose_loaded_markdown_action_link():
+    for viewer_path in REPORT_VIEWERS:
+        viewer = viewer_path.read_text()
+
+        assert 'id="markdown-link"' in viewer
+        assert 'href="index.md"' in viewer
+        assert "Markdown" in viewer
+        assert (
+            "const markdownLinkEl = document.getElementById('markdown-link')" in viewer
+        )
+        assert "const reportPath = resolveReportPath()" in viewer
+        assert "markdownLinkEl.href = reportPath" in viewer
+        assert viewer.index("const reportPath = resolveReportPath()") < viewer.index(
+            "markdownLinkEl.href = reportPath"
+        )
+
+
 def test_report_viewers_label_archived_report_metadata():
     for viewer_path in REPORT_VIEWERS:
         viewer = viewer_path.read_text()


### PR DESCRIPTION
## Summary
- Add a toolbar link to the currently loaded report markdown.
- Route the link through the validated report path used by the viewer.
- Add static guards for the markdown action contract.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_viewer_security.py::test_report_viewers_expose_loaded_markdown_action_link -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`