### PR TITLE
Skip no-op report publish pushes

### DIFF
--- a/.github/workflows/generate-report.yml
+++ b/.github/workflows/generate-report.yml
@@ -66,5 +66,10 @@ jobs:
             git add -f docs/index.html || true
             git add -f docs/executive_summary.mp3 || true
           fi
-          git commit -m "Update exploitation report [automated]" || echo "No changes to commit"
-          git push https://${{ secrets.PAT_GITHUB }}@github.com/${{ github.repository }}.git
+          if git diff --cached --quiet; then
+            echo "No report changes to commit"
+            exit 0
+          fi
+          git commit -m "Update exploitation report [automated]"
+          git pull --rebase origin main
+          git push https://${{ secrets.PAT_GITHUB }}@github.com/${{ github.repository }}.git HEAD:main

--- a/tests/test_validation_gate_contract.py
+++ b/tests/test_validation_gate_contract.py
@@ -15,3 +15,19 @@ def test_generate_report_workflow_checks_root_and_docs_report_markdown():
 
     assert "scripts/validate_report.py index.md" in workflow
     assert "scripts/validate_report.py docs/index.md" in workflow
+
+
+def test_generate_report_workflow_skips_noop_report_pushes():
+    workflow = (REPO_ROOT / ".github" / "workflows" / "generate-report.yml").read_text()
+
+    assert "git diff --cached --quiet" in workflow
+    assert 'echo "No report changes to commit"' in workflow
+    assert "exit 0" in workflow
+    assert 'git commit -m "Update exploitation report [automated]" ||' not in workflow
+
+
+def test_generate_report_workflow_rebases_before_report_push():
+    workflow = (REPO_ROOT / ".github" / "workflows" / "generate-report.yml").read_text()
+
+    assert "git pull --rebase origin main" in workflow
+    assert "HEAD:main" in workflow


### PR DESCRIPTION
## Summary
- Skip the report publish push when no report artifacts changed.
- Rebase generated report commits before pushing to `main`.
- Add workflow contract guards for the publish behavior.

## Validation
- `uv run python -B -W error -m pytest tests/test_validation_gate_contract.py -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`