### PR TITLE
Add archive latest index link

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -109,6 +109,9 @@
         .archive-section-index a:hover {
             text-decoration: none;
         }
+        #archive-summary, #archive-filter-panel, #archive-results {
+            scroll-margin-top: 32px;
+        }
         .archive-filter {
             background: var(--panel);
             border: 1px solid var(--border);
@@ -353,6 +356,7 @@
             <a class="back" href="../index.html">Latest report</a>
         </header>
         <nav class="archive-section-index" aria-label="Archive sections">
+            <a class="archive-focus-target" href="#archive-summary">Latest</a>
             <a class="archive-focus-target" href="#archive-filter-panel">Filter</a>
             <a class="archive-focus-target" href="#archive-results">Reports</a>
         </nav>

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -200,6 +200,7 @@ def test_report_archive_route_has_static_index():
     assert "index.md" in archive
     assert 'id="archive-filter"' in archive
     assert 'id="archive-summary"' in archive
+    assert 'href="#archive-summary"' in archive
     assert 'id="archive-count"' in archive
     assert 'href="#archive-results"' in archive
     assert 'class="archive-results" id="archive-results"' in archive
@@ -284,11 +285,16 @@ def test_report_archive_exposes_static_section_index():
 
     assert 'class="archive-section-index"' in archive
     assert 'aria-label="Archive sections"' in archive
+    assert 'href="#archive-summary"' in archive
     assert 'href="#archive-filter-panel"' in archive
     assert 'href="#archive-results"' in archive
+    assert 'id="archive-summary"' in archive
     assert 'id="archive-filter-panel"' in archive
     assert 'id="archive-results"' in archive
     assert 'id="archive-list"' in archive
+    assert "#archive-summary, #archive-filter-panel, #archive-results" in archive
+    assert "scroll-margin-top: 32px" in archive
+    assert "Latest" in archive
     assert "Filter" in archive
     assert "Reports" in archive
     assert ".archive-section-index" in archive


### PR DESCRIPTION
## Summary
- Add a Latest target to the archive section index.
- Apply anchor scroll offsets to archive summary, filter, and results sections.
- Add static guards for the archive index contract.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_viewer_security.py::test_report_archive_exposes_static_section_index -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`