### PR TITLE
Add archive coverage summary

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -91,6 +91,12 @@
             font-weight: 700;
             margin: 12px 0 16px;
         }
+        .archive-coverage-summary {
+            color: var(--muted);
+            font-size: 0.88rem;
+            margin-top: -8px;
+            max-width: 680px;
+        }
         .archive-section-index {
             align-items: center;
             display: flex;
@@ -352,6 +358,7 @@
                 <h1>Report Archive</h1>
                 <p>Previous SentryInsight exploitation reports.</p>
                 <div class="archive-summary" id="archive-summary"></div>
+                <div class="archive-coverage-summary" id="archive-coverage-summary"></div>
             </div>
             <a class="back" href="../index.html">Latest report</a>
         </header>
@@ -411,6 +418,7 @@
         const archiveFilterEl = document.getElementById('archive-filter');
         const archiveFilterSummaryEl = document.getElementById('archive-filter-summary');
         const archiveSummaryEl = document.getElementById('archive-summary');
+        const archiveCoverageSummaryEl = document.getElementById('archive-coverage-summary');
         const archiveCountEl = document.getElementById('archive-count');
         const archiveEmptyEl = document.getElementById('archive-empty');
         const archiveEmptyClearEl = document.getElementById('archive-empty-clear');
@@ -454,6 +462,22 @@
             latestArchiveLink.href = latestReport.href;
             latestArchiveLink.textContent = latestReport.archivedLabel;
             archiveSummaryEl.appendChild(latestArchiveLink);
+        }
+
+        function renderArchiveCoverageSummary() {
+            if (!archiveReports.length) {
+                archiveCoverageSummaryEl.textContent = 'Coverage notes will appear when archived reports are available.';
+                return;
+            }
+            const sourceAttributionGaps = archiveReports.filter(report =>
+                (report.coverage || []).some(({ label, detail }) =>
+                    label === 'Source attribution' && /no source attribution/i.test(detail || '')
+                )
+            ).length;
+            const artifactTotal = archiveReports.reduce((total, report) => total + Object.keys(report.links || {}).length, 0);
+            const gapText = `${sourceAttributionGaps} ${sourceAttributionGaps === 1 ? 'source attribution gap' : 'source attribution gaps'}`;
+            const artifactText = `${artifactTotal} ${artifactTotal === 1 ? 'archive artifact tracked' : 'archive artifacts tracked'}`;
+            archiveCoverageSummaryEl.textContent = `Coverage: ${gapText} · ${artifactText}.`;
         }
 
         function renderArchiveTopicFilters() {
@@ -724,6 +748,7 @@
         archiveClearFiltersEl.addEventListener('click', clearArchiveFilters);
         archiveEmptyClearEl.addEventListener('click', clearArchiveFilters);
         renderArchiveSummary();
+        renderArchiveCoverageSummary();
         renderArchiveReports();
         renderArchiveTopicFilters();
         sortNewestFirst();

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -348,6 +348,22 @@ def test_report_archive_entries_render_canonical_coverage_signals():
     assert "article.appendChild(buildArchiveCoverageNotes(report))" in archive
 
 
+def test_report_archive_renders_derived_coverage_summary():
+    archive = ARCHIVE_INDEX.read_text()
+
+    assert 'id="archive-coverage-summary"' in archive
+    assert "archiveCoverageSummaryEl" in archive
+    assert "function renderArchiveCoverageSummary()" in archive
+    assert (
+        "archiveReports.reduce((total, report) => total + Object.keys(report.links || {}).length, 0)"
+        in archive
+    )
+    assert "report.coverage || []" in archive
+    assert "source attribution gap" in archive
+    assert "archive artifacts tracked" in archive
+    assert "renderArchiveCoverageSummary();" in archive
+
+
 def test_report_archive_entries_render_artifact_rows_from_links():
     archive = ARCHIVE_INDEX.read_text()
 


### PR DESCRIPTION
## Summary
- Add a derived coverage summary to the report archive header.
- Summarize source-attribution gaps and tracked archive artifacts from existing archive data.
- Add a static guard for the coverage summary contract.

## Validation
- .                                                                        [100%]
1 passed in 0.11s
- All checks passed!
All checks passed!
........................................................................ [ 53%]
..............................................................           [100%]
134 passed in 0.45s
Report content validation passed: index.md
Report content validation passed: docs/index.md