### PR TITLE
Add report coverage artifact path

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1060,6 +1060,7 @@
                 return;
             }
             const notes = [
+                buildCoverageNote('Report artifact', `Loaded markdown artifact: ${reportPath}.`),
                 buildCoverageNote('Section index', `${sections} rendered report sections are included in the page index and section filter.`),
                 buildCoverageNote('Source coverage', sourceEntries
                     ? `${sourceEntries} source attribution entries are available in the provenance panel.`

--- a/index.html
+++ b/index.html
@@ -1060,6 +1060,7 @@
                 return;
             }
             const notes = [
+                buildCoverageNote('Report artifact', `Loaded markdown artifact: ${reportPath}.`),
                 buildCoverageNote('Section index', `${sections} rendered report sections are included in the page index and section filter.`),
                 buildCoverageNote('Source coverage', sourceEntries
                     ? `${sourceEntries} source attribution entries are available in the provenance panel.`

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -438,3 +438,16 @@ def test_report_viewers_include_coverage_notes_panel():
         assert "Section index" in viewer
         assert "Source coverage" in viewer
         assert "Uncertainty coverage" in viewer
+
+
+def test_report_viewers_include_loaded_artifact_in_coverage_notes():
+    for viewer_path in REPORT_VIEWERS:
+        viewer = viewer_path.read_text()
+
+        assert "Report artifact" in viewer
+        assert "reportPath" in viewer
+        assert "Loaded markdown artifact: ${reportPath}." in viewer
+        assert (
+            "buildCoverageNote('Report artifact', `Loaded markdown artifact: ${reportPath}.`)"
+            in viewer
+        )


### PR DESCRIPTION
## Summary
- Add the loaded markdown artifact path to the report coverage panel.
- Apply the coverage note to both static viewer copies.
- Add a guard for the coverage artifact contract.

## Validation
- .                                                                        [100%]
1 passed in 0.28s
- All checks passed!
All checks passed!
........................................................................ [ 53%]
...............................................................          [100%]
135 passed in 1.47s
Report content validation passed: index.md
Report content validation passed: docs/index.md