### PR TITLE
Use report artifact freshness metadata

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -894,14 +894,19 @@
             });
         }
 
-        function renderReportMetadata(dateStr, archiveReport) {
-            const d = new Date();
-            const now = d.toLocaleString();
+        function renderReportMetadata(dateStr, archiveReport, fallbackDateStr = '') {
             if (archiveReport) {
                 metaEl.textContent = 'Archived report';
                 return;
             }
-            metaEl.textContent = `Latest report · Last updated: ${dateStr || now}`;
+            const fallbackDate = fallbackDateStr ? new Date(fallbackDateStr) : null;
+            const fallbackLabel = fallbackDate && !Number.isNaN(fallbackDate.getTime())
+                ? fallbackDate.toLocaleString()
+                : '';
+            const dateLabel = dateStr || fallbackLabel;
+            metaEl.textContent = dateLabel
+                ? `Latest report · Last updated: ${dateLabel}`
+                : 'Latest report';
         }
 
         function computeSummary() {
@@ -1180,8 +1185,11 @@
         markdownLinkEl.href = reportPath;
         Promise.all([configPromise])
           .then(() => fetch(reportPath + '?v=' + Date.now(), { cache: 'no-store' }))
-          .then(response => response.text())
-          .then(text => {
+          .then(response => response.text().then(text => ({
+                text,
+                lastModified: response.headers.get('Last-Modified') || '',
+          })))
+          .then(({ text, lastModified }) => {
                 markdownCache = text;
                 let html = DOMPurify.sanitize(marked.parse(text));
                 contentEl.innerHTML = html;
@@ -1246,7 +1254,7 @@
                 syncReadingIndex();
                 filterSections();
                 const m = text.match(/title:\s*Exploitation Intelligence Report\s*-\s*(\d{4}-\d{2}-\d{2})/i);
-                renderReportMetadata(m ? m[1] : '', isArchiveReport);
+                renderReportMetadata(m ? m[1] : '', isArchiveReport, lastModified);
           })
             .catch(error => {
                 contentEl.innerHTML = `

--- a/index.html
+++ b/index.html
@@ -894,14 +894,19 @@
             });
         }
 
-        function renderReportMetadata(dateStr, archiveReport) {
-            const d = new Date();
-            const now = d.toLocaleString();
+        function renderReportMetadata(dateStr, archiveReport, fallbackDateStr = '') {
             if (archiveReport) {
                 metaEl.textContent = 'Archived report';
                 return;
             }
-            metaEl.textContent = `Latest report · Last updated: ${dateStr || now}`;
+            const fallbackDate = fallbackDateStr ? new Date(fallbackDateStr) : null;
+            const fallbackLabel = fallbackDate && !Number.isNaN(fallbackDate.getTime())
+                ? fallbackDate.toLocaleString()
+                : '';
+            const dateLabel = dateStr || fallbackLabel;
+            metaEl.textContent = dateLabel
+                ? `Latest report · Last updated: ${dateLabel}`
+                : 'Latest report';
         }
 
         function computeSummary() {
@@ -1180,8 +1185,11 @@
         markdownLinkEl.href = reportPath;
         Promise.all([configPromise])
           .then(() => fetch(reportPath + '?v=' + Date.now(), { cache: 'no-store' }))
-          .then(response => response.text())
-          .then(text => {
+          .then(response => response.text().then(text => ({
+                text,
+                lastModified: response.headers.get('Last-Modified') || '',
+          })))
+          .then(({ text, lastModified }) => {
                 markdownCache = text;
                 let html = DOMPurify.sanitize(marked.parse(text));
                 contentEl.innerHTML = html;
@@ -1231,7 +1239,7 @@
                 syncReadingIndex();
                 filterSections();
                 const m = text.match(/title:\s*Exploitation Intelligence Report\s*-\s*(\d{4}-\d{2}-\d{2})/i);
-                renderReportMetadata(m ? m[1] : '', isArchiveReport);
+                renderReportMetadata(m ? m[1] : '', isArchiveReport, lastModified);
           })
             .catch(error => {
                 contentEl.innerHTML = `

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -186,9 +186,21 @@ def test_report_viewers_label_archived_report_metadata():
         viewer = viewer_path.read_text()
 
         assert "renderReportMetadata" in viewer
+        assert (
+            "function renderReportMetadata(dateStr, archiveReport, fallbackDateStr = '')"
+            in viewer
+        )
         assert "Archived report" in viewer
         assert "Latest report" in viewer
         assert "metaEl.textContent = `Last updated:" not in viewer
+        assert "const d = new Date()" not in viewer
+        assert "dateStr || now" not in viewer
+        assert "response.headers.get('Last-Modified') || ''" in viewer
+        assert (
+            "renderReportMetadata(m ? m[1] : '', isArchiveReport, lastModified)"
+            in viewer
+        )
+        assert "fallbackDateStr ? new Date(fallbackDateStr) : null" in viewer
 
 
 def test_report_archive_route_has_static_index():


### PR DESCRIPTION
## Summary
- Use the fetched markdown artifact's freshness metadata for the report header.
- Remove the runtime-clock fallback for latest-report metadata.
- Keep archived report labeling unchanged across both viewer copies.

## Validation
- .                                                                        [100%]
1 passed in 0.06s
- All checks passed!
All checks passed!
........................................................................ [ 53%]
...............................................................          [100%]
135 passed in 0.34s
Report content validation passed: index.md
Report content validation passed: docs/index.md