### PR TITLE
Reject failed report markdown fetches

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1185,10 +1185,15 @@
         markdownLinkEl.href = reportPath;
         Promise.all([configPromise])
           .then(() => fetch(reportPath + '?v=' + Date.now(), { cache: 'no-store' }))
-          .then(response => response.text().then(text => ({
+          .then(response => {
+            if (!response.ok) {
+                throw new Error(`Report fetch failed: ${response.status}`);
+            }
+            return response.text().then(text => ({
                 text,
                 lastModified: response.headers.get('Last-Modified') || '',
-          })))
+            }));
+          })
           .then(({ text, lastModified }) => {
                 markdownCache = text;
                 let html = DOMPurify.sanitize(marked.parse(text));

--- a/index.html
+++ b/index.html
@@ -1185,10 +1185,15 @@
         markdownLinkEl.href = reportPath;
         Promise.all([configPromise])
           .then(() => fetch(reportPath + '?v=' + Date.now(), { cache: 'no-store' }))
-          .then(response => response.text().then(text => ({
+          .then(response => {
+            if (!response.ok) {
+                throw new Error(`Report fetch failed: ${response.status}`);
+            }
+            return response.text().then(text => ({
                 text,
                 lastModified: response.headers.get('Last-Modified') || '',
-          })))
+            }));
+          })
           .then(({ text, lastModified }) => {
                 markdownCache = text;
                 let html = DOMPurify.sanitize(marked.parse(text));

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -203,6 +203,17 @@ def test_report_viewers_label_archived_report_metadata():
         assert "fallbackDateStr ? new Date(fallbackDateStr) : null" in viewer
 
 
+def test_report_viewers_reject_failed_markdown_fetches_before_rendering():
+    for viewer_path in REPORT_VIEWERS:
+        viewer = viewer_path.read_text()
+
+        assert "if (!response.ok)" in viewer
+        assert "Report fetch failed: ${response.status}" in viewer
+        assert "return response.text().then(text => ({" in viewer
+        assert "lastModified: response.headers.get('Last-Modified') || ''" in viewer
+        assert "DOMPurify.sanitize(marked.parse(text))" in viewer
+
+
 def test_report_archive_route_has_static_index():
     archive = ARCHIVE_INDEX.read_text()
 


### PR DESCRIPTION
## Summary
- Reject non-OK report markdown responses before rendering.
- Preserve the successful markdown text and Last-Modified metadata flow for normal report loads.
- Add a static guard for both deployed viewer copies.

## Motivation
A missing or failed markdown response should enter the existing error state instead of passing an error body into the report parser.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_viewer_security.py::test_report_viewers_reject_failed_markdown_fetches_before_rendering -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`
- Local desktop and mobile preview for normal and missing-report routes