### PR TITLE
Add source evidence rows

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -419,6 +419,28 @@
             margin: 4px 0;
             overflow-wrap: anywhere;
         }
+        .source-evidence-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 12px;
+            font-size: .9rem;
+        }
+        .source-evidence-table th,
+        .source-evidence-table td {
+            border-top: 1px solid var(--border-color);
+            padding: 8px 6px;
+            text-align: left;
+            vertical-align: top;
+        }
+        .source-evidence-table th {
+            color: var(--text-secondary);
+            font-size: .78rem;
+            text-transform: uppercase;
+        }
+        .source-evidence-table a {
+            color: var(--accent-color);
+            overflow-wrap: anywhere;
+        }
         body.dark .provenance { background: var(--dark-elev); border-color: #1f2937; }
         body.dark .provenance h4 { color: #cbd5e1; }
         body.dark .provenance p { color: #e5e7eb; }
@@ -964,8 +986,16 @@
             while (el && el.tagName !== 'H2') {
                 if (el.tagName === 'UL' || el.tagName === 'OL') {
                     el.querySelectorAll('li').forEach(li => {
-                        const text = li.textContent.trim().replace(/\s+/g, ' ');
-                        if (text && !isPlaceholderSourceAttributionEntry(text)) entries.push(text);
+                        const raw = li.textContent.trim().replace(/\s+/g, ' ');
+                        const titleEl = li.querySelector('strong');
+                        const title = titleEl ? titleEl.textContent.trim().replace(/\s+/g, ' ') : '';
+                        const titleIndex = title ? raw.indexOf(title) : -1;
+                        const attribution = titleIndex >= 0
+                            ? raw.slice(titleIndex + title.length).trim().replace(/^:\s*/, '')
+                            : raw;
+                        if (raw && !isPlaceholderSourceAttributionEntry(raw)) {
+                            entries.push({ raw, title, attribution });
+                        }
                     });
                 }
                 el = el.nextElementSibling;
@@ -985,12 +1015,77 @@
             sourcePreviewList.innerHTML = '';
             sourceEntries.forEach(entry => {
                 const entryEl = document.createElement('li');
-                entryEl.textContent = entry;
+                entryEl.textContent = entry.raw || entry;
                 sourcePreviewList.appendChild(entryEl);
             });
             preview.appendChild(sourcePreviewList);
 
             return preview;
+        }
+
+        function parseSourceAttributionEntry(entry) {
+            const raw = (entry.raw || entry).trim();
+            const titleFromMarkup = entry.title || '';
+            const attribution = (entry.attribution || raw).trim();
+            const urlMatch = attribution.match(/\bhttps?:\/\/\S+/i);
+            const link = urlMatch ? urlMatch[0].replace(/[.,;]+$/, '') : '';
+            const withoutLink = link
+                ? attribution.replace(urlMatch[0], '').replace(/\s+-\s*$/, '').trim()
+                : attribution;
+            const parts = withoutLink.match(/^(.+?):\s*(.*)$/);
+            const title = titleFromMarkup || (parts ? parts[1].trim() : withoutLink);
+            const source = titleFromMarkup
+                ? withoutLink.replace(/\s+-\s*$/, '')
+                : parts ? parts[2].trim().replace(/\s+-\s*$/, '') : '';
+            return {
+                title: title || 'Untitled evidence',
+                source: source || 'Source not provided',
+                link,
+                raw: entry,
+            };
+        }
+
+        function renderSourceEvidenceRows(sourceEntries) {
+            const rows = sourceEntries.map(parseSourceAttributionEntry);
+            const table = document.createElement('table');
+            table.className = 'source-evidence-table';
+            table.innerHTML = `
+                <thead>
+                    <tr>
+                        <th scope="col">Evidence</th>
+                        <th scope="col">Source</th>
+                        <th scope="col">Link</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            `;
+            const body = table.querySelector('tbody');
+            rows.forEach(row => {
+                const tr = document.createElement('tr');
+                tr.className = 'source-evidence-row';
+
+                const evidence = document.createElement('td');
+                evidence.textContent = row.title || row.raw;
+
+                const source = document.createElement('td');
+                source.textContent = row.source;
+
+                const linkCell = document.createElement('td');
+                if (row.link) {
+                    const link = document.createElement('a');
+                    link.href = row.link;
+                    link.textContent = 'Available';
+                    link.target = '_blank';
+                    link.rel = 'noopener noreferrer';
+                    linkCell.appendChild(link);
+                } else {
+                    linkCell.textContent = row.link ? 'Available' : 'Not provided';
+                }
+
+                tr.append(evidence, source, linkCell);
+                body.appendChild(tr);
+            });
+            return table;
         }
 
         function renderProvenance() {
@@ -1007,6 +1102,7 @@
                 <p>${sourceEntries.length} ${label.toLowerCase()} cited in this report.</p>
                 <div class="provenance-meta">Source entries are rendered from the report's Source Attribution section.</div>
             `;
+            provenanceEl.appendChild(renderSourceEvidenceRows(sourceEntries));
             provenanceEl.appendChild(renderSourcePreview(sourceEntries));
         }
 

--- a/index.html
+++ b/index.html
@@ -419,6 +419,28 @@
             margin: 4px 0;
             overflow-wrap: anywhere;
         }
+        .source-evidence-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 12px;
+            font-size: .9rem;
+        }
+        .source-evidence-table th,
+        .source-evidence-table td {
+            border-top: 1px solid var(--border-color);
+            padding: 8px 6px;
+            text-align: left;
+            vertical-align: top;
+        }
+        .source-evidence-table th {
+            color: var(--text-secondary);
+            font-size: .78rem;
+            text-transform: uppercase;
+        }
+        .source-evidence-table a {
+            color: var(--accent-color);
+            overflow-wrap: anywhere;
+        }
         body.dark .provenance { background: var(--dark-elev); border-color: #1f2937; }
         body.dark .provenance h4 { color: #cbd5e1; }
         body.dark .provenance p { color: #e5e7eb; }
@@ -964,8 +986,16 @@
             while (el && el.tagName !== 'H2') {
                 if (el.tagName === 'UL' || el.tagName === 'OL') {
                     el.querySelectorAll('li').forEach(li => {
-                        const text = li.textContent.trim().replace(/\s+/g, ' ');
-                        if (text && !isPlaceholderSourceAttributionEntry(text)) entries.push(text);
+                        const raw = li.textContent.trim().replace(/\s+/g, ' ');
+                        const titleEl = li.querySelector('strong');
+                        const title = titleEl ? titleEl.textContent.trim().replace(/\s+/g, ' ') : '';
+                        const titleIndex = title ? raw.indexOf(title) : -1;
+                        const attribution = titleIndex >= 0
+                            ? raw.slice(titleIndex + title.length).trim().replace(/^:\s*/, '')
+                            : raw;
+                        if (raw && !isPlaceholderSourceAttributionEntry(raw)) {
+                            entries.push({ raw, title, attribution });
+                        }
                     });
                 }
                 el = el.nextElementSibling;
@@ -985,12 +1015,77 @@
             sourcePreviewList.innerHTML = '';
             sourceEntries.forEach(entry => {
                 const entryEl = document.createElement('li');
-                entryEl.textContent = entry;
+                entryEl.textContent = entry.raw || entry;
                 sourcePreviewList.appendChild(entryEl);
             });
             preview.appendChild(sourcePreviewList);
 
             return preview;
+        }
+
+        function parseSourceAttributionEntry(entry) {
+            const raw = (entry.raw || entry).trim();
+            const titleFromMarkup = entry.title || '';
+            const attribution = (entry.attribution || raw).trim();
+            const urlMatch = attribution.match(/\bhttps?:\/\/\S+/i);
+            const link = urlMatch ? urlMatch[0].replace(/[.,;]+$/, '') : '';
+            const withoutLink = link
+                ? attribution.replace(urlMatch[0], '').replace(/\s+-\s*$/, '').trim()
+                : attribution;
+            const parts = withoutLink.match(/^(.+?):\s*(.*)$/);
+            const title = titleFromMarkup || (parts ? parts[1].trim() : withoutLink);
+            const source = titleFromMarkup
+                ? withoutLink.replace(/\s+-\s*$/, '')
+                : parts ? parts[2].trim().replace(/\s+-\s*$/, '') : '';
+            return {
+                title: title || 'Untitled evidence',
+                source: source || 'Source not provided',
+                link,
+                raw: entry,
+            };
+        }
+
+        function renderSourceEvidenceRows(sourceEntries) {
+            const rows = sourceEntries.map(parseSourceAttributionEntry);
+            const table = document.createElement('table');
+            table.className = 'source-evidence-table';
+            table.innerHTML = `
+                <thead>
+                    <tr>
+                        <th scope="col">Evidence</th>
+                        <th scope="col">Source</th>
+                        <th scope="col">Link</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            `;
+            const body = table.querySelector('tbody');
+            rows.forEach(row => {
+                const tr = document.createElement('tr');
+                tr.className = 'source-evidence-row';
+
+                const evidence = document.createElement('td');
+                evidence.textContent = row.title || row.raw;
+
+                const source = document.createElement('td');
+                source.textContent = row.source;
+
+                const linkCell = document.createElement('td');
+                if (row.link) {
+                    const link = document.createElement('a');
+                    link.href = row.link;
+                    link.textContent = 'Available';
+                    link.target = '_blank';
+                    link.rel = 'noopener noreferrer';
+                    linkCell.appendChild(link);
+                } else {
+                    linkCell.textContent = row.link ? 'Available' : 'Not provided';
+                }
+
+                tr.append(evidence, source, linkCell);
+                body.appendChild(tr);
+            });
+            return table;
         }
 
         function renderProvenance() {
@@ -1007,6 +1102,7 @@
                 <p>${sourceEntries.length} ${label.toLowerCase()} cited in this report.</p>
                 <div class="provenance-meta">Source entries are rendered from the report's Source Attribution section.</div>
             `;
+            provenanceEl.appendChild(renderSourceEvidenceRows(sourceEntries));
             provenanceEl.appendChild(renderSourcePreview(sourceEntries));
         }
 

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -425,6 +425,32 @@ def test_report_viewers_include_source_provenance_panel():
         assert "provenanceEl.hidden = false" in viewer
 
 
+def test_report_viewers_render_source_entries_as_evidence_rows():
+    for viewer_path in REPORT_VIEWERS:
+        viewer = viewer_path.read_text()
+
+        assert "function parseSourceAttributionEntry(entry)" in viewer
+        assert "function renderSourceEvidenceRows(sourceEntries)" in viewer
+        assert "const titleEl = li.querySelector('strong')" in viewer
+        assert "entries.push({ raw, title, attribution })" in viewer
+        assert "const titleFromMarkup = entry.title || ''" in viewer
+        assert r"attribution.match(/\bhttps?:\/\/\S+/i)" in viewer
+        assert r"replace(/[.,;]+$/, '')" in viewer
+        assert "source-evidence-table" in viewer
+        assert "source-evidence-row" in viewer
+        assert "Source" in viewer
+        assert "Evidence" in viewer
+        assert "Link" in viewer
+        assert "row.link ? 'Available' : 'Not provided'" in viewer
+        assert "link.rel = 'noopener noreferrer'" in viewer
+        assert "link.target = '_blank'" in viewer
+        assert "raw: entry" in viewer
+        assert (
+            "provenanceEl.appendChild(renderSourceEvidenceRows(sourceEntries))"
+            in viewer
+        )
+
+
 def test_report_viewers_include_uncertainty_signal_panel():
     for viewer_path in REPORT_VIEWERS:
         viewer = viewer_path.read_text()


### PR DESCRIPTION
## Summary
- Parse report source attribution entries into evidence, source, and link rows.
- Render a compact provenance table before the existing raw source preview.
- Keep external source links isolated with `noopener noreferrer`.

## Motivation
Source attribution entries are easier to scan when the viewer preserves the generated evidence/source/link shape instead of showing only an unstructured list.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_viewer_security.py::test_report_viewers_render_source_entries_as_evidence_rows -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`
- Local desktop and mobile preview with a source-attribution fixture