### PR TITLE
Add source attribution fixture coverage

### DIFF
--- a/tests/fixtures/source_attribution_report.md
+++ b/tests/fixtures/source_attribution_report.md
@@ -1,0 +1,29 @@
+# Exploitation Report
+
+Recent exploitation activity is concentrated in edge systems and package supply
+chains.
+
+## Active Exploitation Details
+
+### Example Vulnerability
+- **Description**: Attackers are exploiting a vulnerable service.
+- **Impact**: Remote access.
+- **Status**: Active exploitation observed.
+
+## Affected Systems and Products
+
+- **Example Product**: Affected versions are exposed.
+
+## Attack Vectors and Techniques
+
+- **Internet-facing service**: Attackers send crafted requests.
+
+## Threat Actor Activities
+
+- **Unknown actor**: Opportunistic exploitation.
+
+## Source Attribution
+
+- **CISA: exploited KEV update**: Example Research - https://example.test/kev
+- **Parenthesized URL report**: Example Source - https://example.test/report(1)
+- **Source-only exploitation report**: Example Source

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -1,4 +1,5 @@
 import unittest
+from pathlib import Path
 
 from src.core.report_validation import (
     ensure_source_attribution_section,
@@ -37,10 +38,32 @@ VALID_REPORT_WITH_SOURCE_ATTRIBUTION = VALID_REPORT + """
 - **Source-only exploitation report**: Example Source
 """
 
+SOURCE_ATTRIBUTION_FIXTURE = (
+    Path(__file__).parent / "fixtures" / "source_attribution_report.md"
+)
+
 
 class ReportValidationTests(unittest.TestCase):
     def test_valid_report_passes(self):
         self.assertEqual(validate_report_content(VALID_REPORT), [])
+
+    def test_source_attribution_report_fixture_validates_expected_rows(self):
+        expected_entries = [
+            "- **CISA: exploited KEV update**: Example Research - https://example.test/kev",
+            "- **Parenthesized URL report**: Example Source - https://example.test/report(1)",
+            "- **Source-only exploitation report**: Example Source",
+        ]
+
+        fixture_markdown = SOURCE_ATTRIBUTION_FIXTURE.read_text(encoding="utf-8")
+
+        self.assertEqual(
+            validate_report_content(
+                fixture_markdown,
+                require_source_attribution=True,
+                source_attribution_entries=expected_entries,
+            ),
+            [],
+        )
 
     def test_ensure_source_attribution_section_appends_canonical_entries(self):
         report = ensure_source_attribution_section(


### PR DESCRIPTION
## Summary
- Add a complete report validation fixture with canonical Source Attribution rows.
- Cover colon-title, parenthesized URL, and source-only source attribution rows through artifact-level validation.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_validation.py::ReportValidationTests::test_source_attribution_report_fixture_validates_expected_rows -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`