### PR TITLE
Add source attribution validator options

### DIFF
--- a/scripts/validate_report.py
+++ b/scripts/validate_report.py
@@ -26,6 +26,17 @@ def main() -> int:
         default="index.md",
         help="Path to the generated markdown report.",
     )
+    parser.add_argument(
+        "--require-source-attribution",
+        action="store_true",
+        help="Fail unless the report contains the expected Source Attribution rows.",
+    )
+    parser.add_argument(
+        "--source-attribution-entry",
+        action="append",
+        default=[],
+        help="Expected canonical Source Attribution row. May be repeated.",
+    )
     args = parser.parse_args()
 
     report_path = Path(args.report_path)
@@ -33,7 +44,13 @@ def main() -> int:
         print(f"Report does not exist: {report_path}")
         return 1
 
-    issues = validate_report_content(report_path.read_text())
+    issues = validate_report_content(
+        report_path.read_text(),
+        require_source_attribution=args.require_source_attribution,
+        source_attribution_entries=(
+            args.source_attribution_entry if args.source_attribution_entry else None
+        ),
+    )
     if issues:
         print("Report content validation failed:")
         print(format_report_validation_issues(issues))

--- a/tests/test_validate_report_cli.py
+++ b/tests/test_validate_report_cli.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+import subprocess
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = REPO_ROOT / "scripts" / "validate_report.py"
+SOURCE_ATTRIBUTION_FIXTURE = (
+    REPO_ROOT / "tests" / "fixtures" / "source_attribution_report.md"
+)
+
+
+def run_validator(*args):
+    return subprocess.run(
+        [sys.executable, "-B", str(VALIDATOR), *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_validate_report_cli_accepts_expected_source_attribution_entries():
+    result = run_validator(
+        "--require-source-attribution",
+        "--source-attribution-entry",
+        "- **CISA: exploited KEV update**: Example Research - https://example.test/kev",
+        "--source-attribution-entry",
+        "- **Parenthesized URL report**: Example Source - https://example.test/report(1)",
+        "--source-attribution-entry",
+        "- **Source-only exploitation report**: Example Source",
+        str(SOURCE_ATTRIBUTION_FIXTURE),
+    )
+
+    assert result.returncode == 0
+    assert "Report content validation passed" in result.stdout
+
+
+def test_validate_report_cli_rejects_missing_source_attribution_entries():
+    result = run_validator(
+        "--require-source-attribution",
+        "--source-attribution-entry",
+        "- **Missing report**: Example Source - https://example.test/missing",
+        str(SOURCE_ATTRIBUTION_FIXTURE),
+    )
+
+    assert result.returncode == 1
+    assert "missing_source_attribution" in result.stdout


### PR DESCRIPTION
## Summary
- Add report validator CLI options for required Source Attribution rows.
- Cover passing and failing exact-row validation through CLI tests.

## Validation
- `uv run python -B -W error -m pytest tests/test_validate_report_cli.py -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`