### PR TITLE
Validate source attribution fixture locally

### DIFF
--- a/scripts/local_validation.sh
+++ b/scripts/local_validation.sh
@@ -12,3 +12,8 @@ uv run ty check
 uv run python -B -W error -m pytest tests -q -p no:cacheprovider
 uv run python -B scripts/validate_report.py index.md
 uv run python -B scripts/validate_report.py docs/index.md
+uv run python -B scripts/validate_report.py tests/fixtures/source_attribution_report.md \
+  --require-source-attribution \
+  --source-attribution-entry '- **CISA: exploited KEV update**: Example Research - https://example.test/kev' \
+  --source-attribution-entry '- **Parenthesized URL report**: Example Source - https://example.test/report(1)' \
+  --source-attribution-entry '- **Source-only exploitation report**: Example Source'

--- a/tests/test_validation_gate_contract.py
+++ b/tests/test_validation_gate_contract.py
@@ -10,6 +10,28 @@ def test_local_validation_checks_root_and_docs_report_markdown():
     assert "scripts/validate_report.py docs/index.md" in script
 
 
+def test_local_validation_checks_source_attribution_fixture():
+    script = (REPO_ROOT / "scripts" / "local_validation.sh").read_text()
+
+    assert (
+        "scripts/validate_report.py tests/fixtures/source_attribution_report.md"
+        in script
+    )
+    assert "--require-source-attribution" in script
+    assert (
+        "--source-attribution-entry '- **CISA: exploited KEV update**: "
+        "Example Research - https://example.test/kev'"
+    ) in script
+    assert (
+        "--source-attribution-entry '- **Parenthesized URL report**: "
+        "Example Source - https://example.test/report(1)'"
+    ) in script
+    assert (
+        "--source-attribution-entry '- **Source-only exploitation report**: "
+        "Example Source'"
+    ) in script
+
+
 def test_generate_report_workflow_checks_root_and_docs_report_markdown():
     workflow = (REPO_ROOT / ".github" / "workflows" / "generate-report.yml").read_text()
 


### PR DESCRIPTION
## Summary
- Run the source attribution fixture through the local validation gate.
- Guard the local validation script so exact Source Attribution rows stay checked.

## Validation
- `uv run python -B -W error -m pytest tests/test_validation_gate_contract.py -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`