### PR TITLE
Normalize source attribution metadata

### DIFF
--- a/src/core/source_attribution.py
+++ b/src/core/source_attribution.py
@@ -8,7 +8,7 @@ UNKNOWN_SOURCE_SENTINELS = {"unknown source"}
 def clean_article_text(value: Any, default: str = "") -> str:
     if value is None:
         return default
-    return str(value).strip()
+    return " ".join(str(value).split())
 
 
 def clean_article_source(value: Any) -> str:
@@ -18,13 +18,19 @@ def clean_article_source(value: Any) -> str:
     return source
 
 
+def clean_article_link(value: Any) -> str:
+    if value is None:
+        return ""
+    return "".join(str(value).split())
+
+
 def collect_source_attribution_entries(articles: list[Dict[str, Any]]) -> list[str]:
     entries: list[str] = []
     for article in articles:
         title = clean_article_text(article.get("title"), "Untitled article")
         title = title or "Untitled article"
         source = clean_article_source(article.get("source"))
-        link = clean_article_text(article.get("link"))
+        link = clean_article_link(article.get("link"))
 
         if link and source:
             entries.append(f"- **{title}**: {source} - {link}")

--- a/tests/test_source_attribution.py
+++ b/tests/test_source_attribution.py
@@ -35,6 +35,23 @@ class SourceAttributionTests(unittest.TestCase):
             ["- **URL-backed report**: https://example.test/report"],
         )
 
+    def test_source_attribution_entries_collapse_metadata_whitespace(self):
+        self.assertEqual(
+            collect_source_attribution_entries(
+                [
+                    {
+                        "title": "Multiline\n exploitation\t report",
+                        "source": "Example\n Research\tTeam",
+                        "link": "https://example.test/\n report",
+                    }
+                ]
+            ),
+            [
+                "- **Multiline exploitation report**: "
+                "Example Research Team - https://example.test/report"
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Collapse internal whitespace in Source Attribution titles and source names.
- Remove whitespace from Source Attribution links before row construction.
- Add coverage for multiline feed metadata.

## Validation
- `uv run python -B -W error -m pytest tests/test_source_attribution.py -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`