### PR TITLE
Deduplicate source attribution rows

### DIFF
--- a/src/core/source_attribution.py
+++ b/src/core/source_attribution.py
@@ -26,6 +26,7 @@ def clean_article_link(value: Any) -> str:
 
 def collect_source_attribution_entries(articles: list[Dict[str, Any]]) -> list[str]:
     entries: list[str] = []
+    seen_entries: set[str] = set()
     for article in articles:
         title = clean_article_text(article.get("title"), "Untitled article")
         title = title or "Untitled article"
@@ -33,10 +34,16 @@ def collect_source_attribution_entries(articles: list[Dict[str, Any]]) -> list[s
         link = clean_article_link(article.get("link"))
 
         if link and source:
-            entries.append(f"- **{title}**: {source} - {link}")
+            entry = f"- **{title}**: {source} - {link}"
         elif link:
-            entries.append(f"- **{title}**: {link}")
+            entry = f"- **{title}**: {link}"
         elif source:
-            entries.append(f"- **{title}**: {source}")
+            entry = f"- **{title}**: {source}"
+        else:
+            continue
+
+        if entry not in seen_entries:
+            entries.append(entry)
+            seen_entries.add(entry)
 
     return entries

--- a/tests/test_source_attribution.py
+++ b/tests/test_source_attribution.py
@@ -52,6 +52,33 @@ class SourceAttributionTests(unittest.TestCase):
             ],
         )
 
+    def test_source_attribution_entries_deduplicate_canonical_rows(self):
+        self.assertEqual(
+            collect_source_attribution_entries(
+                [
+                    {
+                        "title": "First report",
+                        "source": "Example Source",
+                        "link": "https://example.test/first",
+                    },
+                    {
+                        "title": "First report",
+                        "source": "Example Source",
+                        "link": "https://example.test/first",
+                    },
+                    {
+                        "title": "Second report",
+                        "source": "Example Source",
+                        "link": "https://example.test/second",
+                    },
+                ]
+            ),
+            [
+                "- **First report**: Example Source - https://example.test/first",
+                "- **Second report**: Example Source - https://example.test/second",
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Deduplicate canonical Source Attribution rows after metadata normalization.
- Preserve first-seen order for generated provenance rows.
- Add coverage for duplicate feed metadata.

## Validation
- `uv run python -B -W error -m pytest tests/test_source_attribution.py -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`