### PR TITLE
Deduplicate source attribution sections

### DIFF
--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -612,7 +612,15 @@ def remove_source_attribution_section(markdown: str) -> str:
 
 
 def render_source_attribution_section(source_attribution_entries: Iterable[str]) -> str:
-    entries = [entry.strip() for entry in source_attribution_entries if entry.strip()]
+    entries: list[str] = []
+    seen_entries: set[str] = set()
+    for entry in source_attribution_entries:
+        cleaned_entry = entry.strip()
+        if not cleaned_entry or cleaned_entry in seen_entries:
+            continue
+        entries.append(cleaned_entry)
+        seen_entries.add(cleaned_entry)
+
     if not entries:
         return ""
     return f"{SOURCE_ATTRIBUTION_SECTION}\n\n" + "\n".join(entries) + "\n"

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from src.core.report_validation import (
     ensure_source_attribution_section,
+    render_source_attribution_section,
     validate_report_content,
 )
 
@@ -87,6 +88,29 @@ class ReportValidationTests(unittest.TestCase):
                 ],
             ),
             [],
+        )
+
+    def test_render_source_attribution_section_deduplicates_entries(self):
+        section = render_source_attribution_section(
+            [
+                "- **Example exploitation report**: Example Source - https://example.test/report",
+                "  - **Example exploitation report**: Example Source - https://example.test/report  ",
+                "",
+                "- **Second exploitation report**: Example Source - https://example.test/second",
+            ]
+        )
+
+        self.assertEqual(
+            section,
+            "\n".join(
+                [
+                    "## Source Attribution",
+                    "",
+                    "- **Example exploitation report**: Example Source - https://example.test/report",
+                    "- **Second exploitation report**: Example Source - https://example.test/second",
+                    "",
+                ]
+            ),
         )
 
     def test_ensure_source_attribution_section_replaces_existing_section(self):


### PR DESCRIPTION
## Summary
- Deduplicate trimmed Source Attribution rows when rendering report sections.
- Add a regression test for repeated provenance rows while preserving first-seen order.

## Motivation
The report validation renderer should produce canonical provenance sections even if a caller supplies repeated source rows.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_validation.py -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`