### PR TITLE
Escape source attribution metadata text

### DIFF
--- a/src/core/source_attribution.py
+++ b/src/core/source_attribution.py
@@ -3,6 +3,7 @@
 from typing import Any, Dict
 
 UNKNOWN_SOURCE_SENTINELS = {"unknown source"}
+MARKDOWN_TEXT_ESCAPE_CHARACTERS = frozenset(r"\*_[]<>`&~")
 
 
 def clean_article_text(value: Any, default: str = "") -> str:
@@ -24,6 +25,13 @@ def clean_article_link(value: Any) -> str:
     return "".join(str(value).split())
 
 
+def escape_markdown_text(value: str) -> str:
+    return "".join(
+        f"\\{character}" if character in MARKDOWN_TEXT_ESCAPE_CHARACTERS else character
+        for character in value
+    )
+
+
 def collect_source_attribution_entries(articles: list[Dict[str, Any]]) -> list[str]:
     entries: list[str] = []
     seen_entries: set[str] = set()
@@ -32,13 +40,15 @@ def collect_source_attribution_entries(articles: list[Dict[str, Any]]) -> list[s
         title = title or "Untitled article"
         source = clean_article_source(article.get("source"))
         link = clean_article_link(article.get("link"))
+        title_text = escape_markdown_text(title)
+        source_text = escape_markdown_text(source)
 
         if link and source:
-            entry = f"- **{title}**: {source} - {link}"
+            entry = f"- **{title_text}**: {source_text} - {link}"
         elif link:
-            entry = f"- **{title}**: {link}"
+            entry = f"- **{title_text}**: {link}"
         elif source:
-            entry = f"- **{title}**: {source}"
+            entry = f"- **{title_text}**: {source_text}"
         else:
             continue
 

--- a/tests/test_source_attribution.py
+++ b/tests/test_source_attribution.py
@@ -79,6 +79,26 @@ class SourceAttributionTests(unittest.TestCase):
             ],
         )
 
+    def test_source_attribution_entries_escape_markdown_text_metadata(self):
+        self.assertEqual(
+            collect_source_attribution_entries(
+                [
+                    {
+                        "title": r"Critical **edge** [gateway] _update_ \ <em>`advisory`</em> & ~~notes~~",
+                        "source": r"Vendor **Research** [Team] _analysis_ \ <desk>`notes`</desk> & ~~feed~~",
+                        "link": "https://example.test/report(1)",
+                    }
+                ]
+            ),
+            [
+                r"- **Critical \*\*edge\*\* \[gateway\] \_update\_ \\ "
+                r"\<em\>\`advisory\`\</em\> \& \~\~notes\~\~**: "
+                r"Vendor \*\*Research\*\* \[Team\] \_analysis\_ \\ "
+                r"\<desk\>\`notes\`\</desk\> \& \~\~feed\~\~ - "
+                "https://example.test/report(1)"
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Escape Markdown structure characters in source attribution title and source metadata.
- Preserve raw URL text and existing row deduplication behavior.

## Motivation
Generated Source Attribution rows should keep metadata text literal even when feed fields contain Markdown punctuation.

## Validation
- `uv run python -B -W error -m pytest tests/test_source_attribution.py -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`