### PR TITLE
Validate escaped source evidence parsing

### DIFF
--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -39,6 +39,11 @@ def run_source_attribution_parser(viewer):
             "title": "Parenthesized URL report",
             "attribution": "Example Source - https://example.test/report(1)",
         },
+        {
+            "raw": "- **Critical **edge** [gateway] _update_ \\ <em>`advisory`</em> & ~~notes~~**: Vendor **Research** [Team] _analysis_ \\ <desk>`notes`</desk> & ~~feed~~ - https://example.test/report(1)",
+            "title": "Critical **edge** [gateway] _update_ \\ <em>`advisory`</em> & ~~notes~~",
+            "attribution": "Vendor **Research** [Team] _analysis_ \\ <desk>`notes`</desk> & ~~feed~~ - https://example.test/report(1)",
+        },
     ]
     script = textwrap.dedent(f"""
         {parser}
@@ -511,6 +516,12 @@ def test_report_viewers_parse_source_entries_behaviorally():
             "source": "Example Source",
             "link": "https://example.test/report(1)",
             "raw": "- **Parenthesized URL report**: Example Source - https://example.test/report(1)",
+        },
+        {
+            "title": "Critical **edge** [gateway] _update_ \\ <em>`advisory`</em> & ~~notes~~",
+            "source": "Vendor **Research** [Team] _analysis_ \\ <desk>`notes`</desk> & ~~feed~~",
+            "link": "https://example.test/report(1)",
+            "raw": "- **Critical **edge** [gateway] _update_ \\ <em>`advisory`</em> & ~~notes~~**: Vendor **Research** [Team] _analysis_ \\ <desk>`notes`</desk> & ~~feed~~ - https://example.test/report(1)",
         },
     ]
     for viewer_path in REPORT_VIEWERS:


### PR DESCRIPTION
## Summary
- Add viewer parser coverage for escaped Source Attribution metadata.
- Verify evidence rows preserve literal Markdown and HTML delimiter text while keeping URL extraction stable.

## Motivation
Source evidence parsing should stay stable when generated attribution rows contain escaped metadata punctuation.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_viewer_security.py -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`