### PR TITLE
Add report coverage summary chips

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -479,6 +479,30 @@
             margin: 0 0 6px;
             color: var(--text-secondary);
         }
+        .coverage-summary {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin: 0 0 10px;
+        }
+        .coverage-chip {
+            display: inline-flex;
+            align-items: baseline;
+            gap: 6px;
+            min-width: 0;
+            border: 1px solid var(--border-color);
+            border-radius: 999px;
+            padding: 5px 9px;
+            background: #f8fafc;
+            color: var(--text-secondary);
+            font-size: 0.82rem;
+            line-height: 1.2;
+            white-space: normal;
+        }
+        .coverage-chip strong {
+            color: var(--text-primary);
+            font-size: 0.95rem;
+        }
         .coverage-notes ul {
             margin: 0;
             padding-left: 18px;
@@ -493,6 +517,8 @@
         body.dark .coverage-notes { background: var(--dark-elev); border-color: #1f2937; }
         body.dark .coverage-notes h4 { color: #cbd5e1; }
         body.dark .coverage-notes li { color: #e5e7eb; }
+        body.dark .coverage-chip { background: #0b1220; border-color: #1f2937; color: #cbd5e1; }
+        body.dark .coverage-chip strong { color: #e5e7eb; }
 
         /* Add loading animation */
         .loading {
@@ -1151,6 +1177,15 @@
             return item;
         }
 
+        function buildCoverageSummaryChip(label, value) {
+            const chip = document.createElement('span');
+            chip.className = 'coverage-chip';
+            const valueEl = document.createElement('strong');
+            valueEl.textContent = value;
+            chip.append(valueEl, document.createTextNode(label));
+            return chip;
+        }
+
         function renderCoverageNotes() {
             const sections = buildFilterGroups().length;
             const sourceEntries = extractSourceAttributionEntries().length;
@@ -1174,9 +1209,16 @@
             coverageNotesEl.innerHTML = '';
             const heading = document.createElement('h4');
             heading.textContent = 'Report Coverage';
+            const summary = document.createElement('div');
+            summary.className = 'coverage-summary';
+            summary.append(
+                buildCoverageSummaryChip('Sections', String(sections)),
+                buildCoverageSummaryChip('Sources', String(sourceEntries)),
+                buildCoverageSummaryChip('Uncertainty', String(uncertaintySignals))
+            );
             const list = document.createElement('ul');
             notes.forEach(note => list.appendChild(note));
-            coverageNotesEl.append(heading, list);
+            coverageNotesEl.append(heading, summary, list);
         }
 
         function buildFilterGroups() {

--- a/index.html
+++ b/index.html
@@ -479,6 +479,30 @@
             margin: 0 0 6px;
             color: var(--text-secondary);
         }
+        .coverage-summary {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin: 0 0 10px;
+        }
+        .coverage-chip {
+            display: inline-flex;
+            align-items: baseline;
+            gap: 6px;
+            min-width: 0;
+            border: 1px solid var(--border-color);
+            border-radius: 999px;
+            padding: 5px 9px;
+            background: #f8fafc;
+            color: var(--text-secondary);
+            font-size: 0.82rem;
+            line-height: 1.2;
+            white-space: normal;
+        }
+        .coverage-chip strong {
+            color: var(--text-primary);
+            font-size: 0.95rem;
+        }
         .coverage-notes ul {
             margin: 0;
             padding-left: 18px;
@@ -493,6 +517,8 @@
         body.dark .coverage-notes { background: var(--dark-elev); border-color: #1f2937; }
         body.dark .coverage-notes h4 { color: #cbd5e1; }
         body.dark .coverage-notes li { color: #e5e7eb; }
+        body.dark .coverage-chip { background: #0b1220; border-color: #1f2937; color: #cbd5e1; }
+        body.dark .coverage-chip strong { color: #e5e7eb; }
 
         /* Add loading animation */
         .loading {
@@ -1151,6 +1177,15 @@
             return item;
         }
 
+        function buildCoverageSummaryChip(label, value) {
+            const chip = document.createElement('span');
+            chip.className = 'coverage-chip';
+            const valueEl = document.createElement('strong');
+            valueEl.textContent = value;
+            chip.append(valueEl, document.createTextNode(label));
+            return chip;
+        }
+
         function renderCoverageNotes() {
             const sections = buildFilterGroups().length;
             const sourceEntries = extractSourceAttributionEntries().length;
@@ -1174,9 +1209,16 @@
             coverageNotesEl.innerHTML = '';
             const heading = document.createElement('h4');
             heading.textContent = 'Report Coverage';
+            const summary = document.createElement('div');
+            summary.className = 'coverage-summary';
+            summary.append(
+                buildCoverageSummaryChip('Sections', String(sections)),
+                buildCoverageSummaryChip('Sources', String(sourceEntries)),
+                buildCoverageSummaryChip('Uncertainty', String(uncertaintySignals))
+            );
             const list = document.createElement('ul');
             notes.forEach(note => list.appendChild(note));
-            coverageNotesEl.append(heading, list);
+            coverageNotesEl.append(heading, summary, list);
         }
 
         function buildFilterGroups() {

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -558,14 +558,21 @@ def test_report_viewers_include_coverage_notes_panel():
         assert "Report Coverage" in viewer
         assert "renderCoverageNotes" in viewer
         assert "buildCoverageNote" in viewer
+        assert "buildCoverageSummaryChip" in viewer
+        assert "coverage-summary" in viewer
+        assert "coverage-chip" in viewer
         assert "coverageNotesEl.hidden = true" in viewer
         assert "coverageNotesEl.hidden = false" in viewer
         assert "const sections = buildFilterGroups().length" in viewer
         assert "extractSourceAttributionEntries().length" in viewer
         assert "countUncertaintySignals()" in viewer
+        assert "Sections" in viewer
+        assert "Sources" in viewer
+        assert "Uncertainty" in viewer
         assert "Section index" in viewer
         assert "Source coverage" in viewer
         assert "Uncertainty coverage" in viewer
+        assert "coverageNotesEl.append(heading, summary, list)" in viewer
 
 
 def test_report_viewers_include_loaded_artifact_in_coverage_notes():


### PR DESCRIPTION
## Summary
- Add compact coverage chips to the report Coverage panel.
- Derive section, source, and uncertainty counts from existing viewer state.

## Motivation
The Coverage panel should expose scan-friendly counts before the detailed coverage notes.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_viewer_security.py -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`