### PR TITLE
Add coverage chip accessible labels

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1182,7 +1182,7 @@
             chip.className = 'coverage-chip';
             const valueEl = document.createElement('strong');
             valueEl.textContent = value;
-            chip.append(valueEl, document.createTextNode(label));
+            chip.append(valueEl, document.createTextNode(` ${label}`));
             return chip;
         }
 

--- a/index.html
+++ b/index.html
@@ -1182,7 +1182,7 @@
             chip.className = 'coverage-chip';
             const valueEl = document.createElement('strong');
             valueEl.textContent = value;
-            chip.append(valueEl, document.createTextNode(label));
+            chip.append(valueEl, document.createTextNode(` ${label}`));
             return chip;
         }
 

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -561,6 +561,8 @@ def test_report_viewers_include_coverage_notes_panel():
         assert "buildCoverageSummaryChip" in viewer
         assert "coverage-summary" in viewer
         assert "coverage-chip" in viewer
+        assert "chip.setAttribute('aria-label'" not in viewer
+        assert "chip.append(valueEl, document.createTextNode(` ${label}`))" in viewer
         assert "coverageNotesEl.hidden = true" in viewer
         assert "coverageNotesEl.hidden = false" in viewer
         assert "const sections = buildFilterGroups().length" in viewer


### PR DESCRIPTION
## Summary
- Add accessible labels to the Coverage panel summary chips.
- Keep the existing section, source, and uncertainty count owners unchanged.

## Motivation
Coverage counts should expose the same count-and-label relationship to assistive technology that the visual chip layout shows.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_viewer_security.py -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`

Closes #81