### PR TITLE
Fix archive topic count text

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -439,7 +439,6 @@
             label.textContent = topic || 'All';
             const count = document.createElement('span');
             count.className = 'archive-topic-count';
-            count.setAttribute('aria-label', `${total} ${total === 1 ? 'report' : 'reports'}`);
             count.textContent = String(total);
             button.append(label, ' ', count);
             return button;

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -313,6 +313,8 @@ def test_report_archive_route_has_static_index():
     assert "topicCounts" in archive
     assert "label.textContent = topic || 'All'" in archive
     assert "count.textContent = String(total)" in archive
+    assert "count.setAttribute('aria-label'" not in archive
+    assert "button.append(label, ' ', count)" in archive
     assert "createElement('article')" in archive
     assert "createElement('button')" in archive
     assert "archiveTagLabel.className = 'archive-tag-label'" in archive


### PR DESCRIPTION
## Summary
- Remove the redundant ARIA label from archive topic count spans.
- Keep topic filter buttons exposing label and count through real button text.

## Motivation
Archive topic counts should use the visible button text as the accessibility contract instead of naming a generic span.

## Validation
- `uv run python -B -W error -m pytest tests/test_report_viewer_security.py -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`

Closes #83