### PR TITLE
Escape report load error details

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1321,6 +1321,16 @@
         const reportPath = resolveReportPath();
         const isArchiveReport = reportPath !== 'index.md';
         markdownLinkEl.href = reportPath;
+        function renderReportLoadError(error) {
+            const heading = document.createElement('h1');
+            heading.textContent = 'Error Loading Report';
+            const message = document.createElement('p');
+            message.textContent = 'Unable to load the exploitation report. Please check back later.';
+            const pre = document.createElement('pre');
+            pre.textContent = String(error);
+            contentEl.textContent = '';
+            contentEl.append(heading, message, pre);
+        }
         Promise.all([configPromise])
           .then(() => fetch(reportPath + '?v=' + Date.now(), { cache: 'no-store' }))
           .then(response => {
@@ -1400,11 +1410,7 @@
                 renderReportMetadata(m ? m[1] : '', isArchiveReport, lastModified);
           })
             .catch(error => {
-                contentEl.innerHTML = `
-                    <h1>Error Loading Report</h1>
-                    <p>Unable to load the exploitation report. Please check back later.</p>
-                    <pre>${error}</pre>
-                `;
+                renderReportLoadError(error);
             });
 
         // Controls

--- a/index.html
+++ b/index.html
@@ -1321,6 +1321,16 @@
         const reportPath = resolveReportPath();
         const isArchiveReport = reportPath !== 'index.md';
         markdownLinkEl.href = reportPath;
+        function renderReportLoadError(error) {
+            const heading = document.createElement('h1');
+            heading.textContent = 'Error Loading Report';
+            const message = document.createElement('p');
+            message.textContent = 'Unable to load the exploitation report. Please check back later.';
+            const pre = document.createElement('pre');
+            pre.textContent = String(error);
+            contentEl.textContent = '';
+            contentEl.append(heading, message, pre);
+        }
         Promise.all([configPromise])
           .then(() => fetch(reportPath + '?v=' + Date.now(), { cache: 'no-store' }))
           .then(response => {
@@ -1385,11 +1395,7 @@
                 renderReportMetadata(m ? m[1] : '', isArchiveReport, lastModified);
           })
             .catch(error => {
-                contentEl.innerHTML = `
-                    <h1>Error Loading Report</h1>
-                    <p>Unable to load the exploitation report. Please check back later.</p>
-                    <pre>${error}</pre>
-                `;
+                renderReportLoadError(error);
             });
 
         // Controls

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -266,6 +266,17 @@ def test_report_viewers_reject_failed_markdown_fetches_before_rendering():
         assert "DOMPurify.sanitize(marked.parse(text))" in viewer
 
 
+def test_report_viewers_render_load_error_details_as_text():
+    for viewer_path in REPORT_VIEWERS:
+        viewer = viewer_path.read_text()
+
+        assert "function renderReportLoadError(error)" in viewer
+        assert "contentEl.textContent = ''" in viewer
+        assert "pre.textContent = String(error)" in viewer
+        assert "renderReportLoadError(error)" in viewer
+        assert "<pre>${error}</pre>" not in viewer
+
+
 def test_report_archive_route_has_static_index():
     archive = ARCHIVE_INDEX.read_text()
 


### PR DESCRIPTION
## Summary
- Render report load-error details with DOM nodes instead of an HTML template.
- Assign the technical error detail with `textContent` in both viewer copies.
- Add a viewer guard for the safe error-rendering path.

Closes #85

## Validation
- `python -B -W error -m pytest tests/test_report_viewer_security.py -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`
- Desktop and mobile missing-report preview checks