### PR TITLE
Reset report chrome on load failure

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1322,6 +1322,19 @@
         const isArchiveReport = reportPath !== 'index.md';
         markdownLinkEl.href = reportPath;
         function renderReportLoadError(error) {
+            metaEl.textContent = 'Report unavailable';
+            summaryEl.textContent = '';
+            tocEl.textContent = '';
+            execEl.textContent = '';
+            sectionFilterCountEl.textContent = '';
+            sectionFilterEmptyEl.style.display = 'none';
+            provenanceEl.hidden = true;
+            provenanceEl.textContent = '';
+            uncertaintyEl.hidden = true;
+            uncertaintyEl.textContent = '';
+            coverageNotesEl.hidden = true;
+            coverageNotesEl.textContent = '';
+            syncReadingIndex();
             const heading = document.createElement('h1');
             heading.textContent = 'Error Loading Report';
             const message = document.createElement('p');

--- a/index.html
+++ b/index.html
@@ -1322,6 +1322,19 @@
         const isArchiveReport = reportPath !== 'index.md';
         markdownLinkEl.href = reportPath;
         function renderReportLoadError(error) {
+            metaEl.textContent = 'Report unavailable';
+            summaryEl.textContent = '';
+            tocEl.textContent = '';
+            execEl.textContent = '';
+            sectionFilterCountEl.textContent = '';
+            sectionFilterEmptyEl.style.display = 'none';
+            provenanceEl.hidden = true;
+            provenanceEl.textContent = '';
+            uncertaintyEl.hidden = true;
+            uncertaintyEl.textContent = '';
+            coverageNotesEl.hidden = true;
+            coverageNotesEl.textContent = '';
+            syncReadingIndex();
             const heading = document.createElement('h1');
             heading.textContent = 'Error Loading Report';
             const message = document.createElement('p');

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -277,6 +277,32 @@ def test_report_viewers_render_load_error_details_as_text():
         assert "<pre>${error}</pre>" not in viewer
 
 
+def test_report_viewers_reset_report_chrome_on_load_error():
+    for viewer_path in REPORT_VIEWERS:
+        viewer = viewer_path.read_text()
+
+        assert "metaEl.textContent = 'Report unavailable'" in viewer
+        assert "summaryEl.textContent = ''" in viewer
+        assert "tocEl.textContent = ''" in viewer
+        assert "execEl.textContent = ''" in viewer
+        assert "sectionFilterCountEl.textContent = ''" in viewer
+        assert "sectionFilterEmptyEl.style.display = 'none'" in viewer
+        assert "provenanceEl.hidden = true" in viewer
+        assert "provenanceEl.textContent = ''" in viewer
+        assert "uncertaintyEl.hidden = true" in viewer
+        assert "uncertaintyEl.textContent = ''" in viewer
+        assert "coverageNotesEl.hidden = true" in viewer
+        assert "coverageNotesEl.textContent = ''" in viewer
+        assert (
+            "syncReadingIndex()"
+            in viewer[
+                viewer.index("function renderReportLoadError(error)") : viewer.index(
+                    "Promise.all([configPromise])"
+                )
+            ]
+        )
+
+
 def test_report_archive_route_has_static_index():
     archive = ARCHIVE_INDEX.read_text()
 


### PR DESCRIPTION
## Summary
- Reset report-derived metadata, summary, TOC, panels, and filter feedback when report loading fails.
- Keep the missing-report error detail as plain text.
- Add a viewer guard for the load-failure chrome reset.

Closes #87

## Validation
- `python -B -W error -m pytest tests/test_report_viewer_security.py -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`
- Desktop and mobile missing-report preview checks