### PR TITLE
Hide report navigation on load failure

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -355,6 +355,9 @@
             gap: 8px;
             margin: 0 0 16px;
         }
+        .reading-index[hidden] {
+            display: none;
+        }
         .reading-index a {
             border: 1px solid var(--border-color);
             border-radius: 8px;

--- a/docs/index.html
+++ b/docs/index.html
@@ -650,6 +650,7 @@
     <script>
         const contentEl = document.getElementById('content');
         const tocEl = document.getElementById('toc-list');
+        const tocAsideEl = document.getElementById('toc');
         const metaEl = document.getElementById('meta');
         const summaryEl = document.getElementById('summary');
         const provenanceEl = document.getElementById('provenance');
@@ -1327,6 +1328,7 @@
             metaEl.textContent = 'Report unavailable';
             summaryEl.textContent = '';
             tocEl.textContent = '';
+            tocAsideEl.classList.add('hidden');
             execEl.textContent = '';
             readingIndexEl.hidden = true;
             sectionFilterPanelEl.hidden = true;
@@ -1361,6 +1363,7 @@
             }));
           })
           .then(({ text, lastModified }) => {
+                tocAsideEl.classList.remove('hidden');
                 readingIndexEl.hidden = false;
                 sectionFilterPanelEl.hidden = false;
                 markdownCache = text;

--- a/docs/index.html
+++ b/docs/index.html
@@ -655,12 +655,14 @@
         const provenanceEl = document.getElementById('provenance');
         const uncertaintyEl = document.getElementById('uncertainty');
         const coverageNotesEl = document.getElementById('coverage-notes');
+        const readingIndexEl = document.querySelector('.reading-index');
         const readingIndexSourceEl = document.getElementById('reading-index-sources');
         const readingIndexUncertaintyEl = document.getElementById('reading-index-uncertainty');
         const toggleDarkEl = document.getElementById('toggle-dark');
         const markdownLinkEl = document.getElementById('markdown-link');
         const archiveLinkEl = document.getElementById('archive-link');
         const execEl = document.getElementById('exec');
+        const sectionFilterPanelEl = document.getElementById('section-filter-panel');
         const sectionFilterEl = document.getElementById('section-filter');
         const sectionFilterCountEl = document.getElementById('section-filter-count');
         const sectionFilterEmptyEl = document.getElementById('section-filter-empty');
@@ -1326,6 +1328,9 @@
             summaryEl.textContent = '';
             tocEl.textContent = '';
             execEl.textContent = '';
+            readingIndexEl.hidden = true;
+            sectionFilterPanelEl.hidden = true;
+            sectionFilterEl.value = '';
             sectionFilterCountEl.textContent = '';
             sectionFilterEmptyEl.style.display = 'none';
             provenanceEl.hidden = true;
@@ -1356,6 +1361,8 @@
             }));
           })
           .then(({ text, lastModified }) => {
+                readingIndexEl.hidden = false;
+                sectionFilterPanelEl.hidden = false;
                 markdownCache = text;
                 let html = DOMPurify.sanitize(marked.parse(text));
                 contentEl.innerHTML = html;

--- a/docs/index.html
+++ b/docs/index.html
@@ -102,6 +102,12 @@
             align-items: start;
             margin-top: 16px;
         }
+        .layout.report-unavailable {
+            grid-template-columns: minmax(0, 1fr);
+        }
+        .layout.report-unavailable main {
+            grid-column: 1;
+        }
         .layout > *, main, aside#toc, #content {
             min-width: 0;
         }
@@ -651,6 +657,7 @@
     </div>
 
     <script>
+        const layoutEl = document.querySelector('.layout');
         const contentEl = document.getElementById('content');
         const tocEl = document.getElementById('toc-list');
         const tocAsideEl = document.getElementById('toc');
@@ -1328,6 +1335,7 @@
         const isArchiveReport = reportPath !== 'index.md';
         markdownLinkEl.href = reportPath;
         function renderReportLoadError(error) {
+            layoutEl.classList.add('report-unavailable');
             metaEl.textContent = 'Report unavailable';
             summaryEl.textContent = '';
             tocEl.textContent = '';
@@ -1366,6 +1374,7 @@
             }));
           })
           .then(({ text, lastModified }) => {
+                layoutEl.classList.remove('report-unavailable');
                 tocAsideEl.classList.remove('hidden');
                 readingIndexEl.hidden = false;
                 sectionFilterPanelEl.hidden = false;

--- a/index.html
+++ b/index.html
@@ -355,6 +355,9 @@
             gap: 8px;
             margin: 0 0 16px;
         }
+        .reading-index[hidden] {
+            display: none;
+        }
         .reading-index a {
             border: 1px solid var(--border-color);
             border-radius: 8px;

--- a/index.html
+++ b/index.html
@@ -650,6 +650,7 @@
     <script>
         const contentEl = document.getElementById('content');
         const tocEl = document.getElementById('toc-list');
+        const tocAsideEl = document.getElementById('toc');
         const metaEl = document.getElementById('meta');
         const summaryEl = document.getElementById('summary');
         const provenanceEl = document.getElementById('provenance');
@@ -1327,6 +1328,7 @@
             metaEl.textContent = 'Report unavailable';
             summaryEl.textContent = '';
             tocEl.textContent = '';
+            tocAsideEl.classList.add('hidden');
             execEl.textContent = '';
             readingIndexEl.hidden = true;
             sectionFilterPanelEl.hidden = true;
@@ -1361,6 +1363,7 @@
             }));
           })
           .then(({ text, lastModified }) => {
+                tocAsideEl.classList.remove('hidden');
                 readingIndexEl.hidden = false;
                 sectionFilterPanelEl.hidden = false;
                 markdownCache = text;

--- a/index.html
+++ b/index.html
@@ -655,12 +655,14 @@
         const provenanceEl = document.getElementById('provenance');
         const uncertaintyEl = document.getElementById('uncertainty');
         const coverageNotesEl = document.getElementById('coverage-notes');
+        const readingIndexEl = document.querySelector('.reading-index');
         const readingIndexSourceEl = document.getElementById('reading-index-sources');
         const readingIndexUncertaintyEl = document.getElementById('reading-index-uncertainty');
         const toggleDarkEl = document.getElementById('toggle-dark');
         const markdownLinkEl = document.getElementById('markdown-link');
         const archiveLinkEl = document.getElementById('archive-link');
         const execEl = document.getElementById('exec');
+        const sectionFilterPanelEl = document.getElementById('section-filter-panel');
         const sectionFilterEl = document.getElementById('section-filter');
         const sectionFilterCountEl = document.getElementById('section-filter-count');
         const sectionFilterEmptyEl = document.getElementById('section-filter-empty');
@@ -1326,6 +1328,9 @@
             summaryEl.textContent = '';
             tocEl.textContent = '';
             execEl.textContent = '';
+            readingIndexEl.hidden = true;
+            sectionFilterPanelEl.hidden = true;
+            sectionFilterEl.value = '';
             sectionFilterCountEl.textContent = '';
             sectionFilterEmptyEl.style.display = 'none';
             provenanceEl.hidden = true;
@@ -1356,6 +1361,8 @@
             }));
           })
           .then(({ text, lastModified }) => {
+                readingIndexEl.hidden = false;
+                sectionFilterPanelEl.hidden = false;
                 markdownCache = text;
                 let html = DOMPurify.sanitize(marked.parse(text));
                 contentEl.innerHTML = html;

--- a/index.html
+++ b/index.html
@@ -102,6 +102,12 @@
             align-items: start;
             margin-top: 16px;
         }
+        .layout.report-unavailable {
+            grid-template-columns: minmax(0, 1fr);
+        }
+        .layout.report-unavailable main {
+            grid-column: 1;
+        }
         .layout > *, main, aside#toc, #content {
             min-width: 0;
         }
@@ -651,6 +657,7 @@
     </div>
 
     <script>
+        const layoutEl = document.querySelector('.layout');
         const contentEl = document.getElementById('content');
         const tocEl = document.getElementById('toc-list');
         const tocAsideEl = document.getElementById('toc');
@@ -1328,6 +1335,7 @@
         const isArchiveReport = reportPath !== 'index.md';
         markdownLinkEl.href = reportPath;
         function renderReportLoadError(error) {
+            layoutEl.classList.add('report-unavailable');
             metaEl.textContent = 'Report unavailable';
             summaryEl.textContent = '';
             tocEl.textContent = '';
@@ -1366,6 +1374,7 @@
             }));
           })
           .then(({ text, lastModified }) => {
+                layoutEl.classList.remove('report-unavailable');
                 tocAsideEl.classList.remove('hidden');
                 readingIndexEl.hidden = false;
                 sectionFilterPanelEl.hidden = false;

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -303,6 +303,34 @@ def test_report_viewers_reset_report_chrome_on_load_error():
         )
 
 
+def test_report_viewers_hide_report_navigation_on_load_error():
+    for viewer_path in REPORT_VIEWERS:
+        viewer = viewer_path.read_text()
+        load_error_helper = viewer[
+            viewer.index("function renderReportLoadError(error)") : viewer.index(
+                "Promise.all([configPromise])"
+            )
+        ]
+        success_path = viewer[
+            viewer.index(".then(({ text, lastModified }) => {") : viewer.index(
+                "markdownCache = text;"
+            )
+        ]
+
+        assert (
+            "const readingIndexEl = document.querySelector('.reading-index')" in viewer
+        )
+        assert (
+            "const sectionFilterPanelEl = document.getElementById('section-filter-panel')"
+            in viewer
+        )
+        assert "readingIndexEl.hidden = true" in load_error_helper
+        assert "sectionFilterPanelEl.hidden = true" in load_error_helper
+        assert "sectionFilterEl.value = ''" in load_error_helper
+        assert "readingIndexEl.hidden = false" in success_path
+        assert "sectionFilterPanelEl.hidden = false" in success_path
+
+
 def test_report_archive_route_has_static_index():
     archive = ARCHIVE_INDEX.read_text()
 

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -317,6 +317,9 @@ def test_report_viewers_hide_report_navigation_on_load_error():
             )
         ]
 
+        assert ".layout.report-unavailable" in viewer
+        assert ".layout.report-unavailable main" in viewer
+        assert "const layoutEl = document.querySelector('.layout')" in viewer
         assert "const tocAsideEl = document.getElementById('toc')" in viewer
         assert ".reading-index[hidden]" in viewer
         assert (
@@ -326,10 +329,12 @@ def test_report_viewers_hide_report_navigation_on_load_error():
             "const sectionFilterPanelEl = document.getElementById('section-filter-panel')"
             in viewer
         )
+        assert "layoutEl.classList.add('report-unavailable')" in load_error_helper
         assert "tocAsideEl.classList.add('hidden')" in load_error_helper
         assert "readingIndexEl.hidden = true" in load_error_helper
         assert "sectionFilterPanelEl.hidden = true" in load_error_helper
         assert "sectionFilterEl.value = ''" in load_error_helper
+        assert "layoutEl.classList.remove('report-unavailable')" in success_path
         assert "tocAsideEl.classList.remove('hidden')" in success_path
         assert "readingIndexEl.hidden = false" in success_path
         assert "sectionFilterPanelEl.hidden = false" in success_path

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -318,6 +318,7 @@ def test_report_viewers_hide_report_navigation_on_load_error():
         ]
 
         assert "const tocAsideEl = document.getElementById('toc')" in viewer
+        assert ".reading-index[hidden]" in viewer
         assert (
             "const readingIndexEl = document.querySelector('.reading-index')" in viewer
         )

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -317,6 +317,7 @@ def test_report_viewers_hide_report_navigation_on_load_error():
             )
         ]
 
+        assert "const tocAsideEl = document.getElementById('toc')" in viewer
         assert (
             "const readingIndexEl = document.querySelector('.reading-index')" in viewer
         )
@@ -324,9 +325,11 @@ def test_report_viewers_hide_report_navigation_on_load_error():
             "const sectionFilterPanelEl = document.getElementById('section-filter-panel')"
             in viewer
         )
+        assert "tocAsideEl.classList.add('hidden')" in load_error_helper
         assert "readingIndexEl.hidden = true" in load_error_helper
         assert "sectionFilterPanelEl.hidden = true" in load_error_helper
         assert "sectionFilterEl.value = ''" in load_error_helper
+        assert "tocAsideEl.classList.remove('hidden')" in success_path
         assert "readingIndexEl.hidden = false" in success_path
         assert "sectionFilterPanelEl.hidden = false" in success_path
 


### PR DESCRIPTION
## Summary
- Hide report-only navigation and section-filter controls when report loading fails.
- Clear the filter input in the unavailable-report state.
- Add a viewer guard for the error-state navigation contract.

Closes #89

## Validation
- `python -B -W error -m pytest tests/test_report_viewer_security.py -q -p no:cacheprovider`
- `bash scripts/local_validation.sh`
- Desktop and mobile missing-report preview checks