### PR TITLE
Expose section filter count as status

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -642,7 +642,7 @@
                 <div class="section-filter" id="section-filter-panel">
                     <label for="section-filter">Filter report sections</label>
                     <input id="section-filter" type="search" autocomplete="off" placeholder="Search vulnerabilities, products, actors, or techniques" />
-                    <div class="filter-meta" id="section-filter-count"></div>
+                    <div class="filter-meta" id="section-filter-count" role="status" aria-live="polite" aria-atomic="true"></div>
                 </div>
                 <section class="report-results" id="report-results" aria-label="Report sections">
                     <div class="section-filter-empty" id="section-filter-empty">

--- a/index.html
+++ b/index.html
@@ -642,7 +642,7 @@
                 <div class="section-filter" id="section-filter-panel">
                     <label for="section-filter">Filter report sections</label>
                     <input id="section-filter" type="search" autocomplete="off" placeholder="Search vulnerabilities, products, actors, or techniques" />
-                    <div class="filter-meta" id="section-filter-count"></div>
+                    <div class="filter-meta" id="section-filter-count" role="status" aria-live="polite" aria-atomic="true"></div>
                 </div>
                 <section class="report-results" id="report-results" aria-label="Report sections">
                     <div class="section-filter-empty" id="section-filter-empty">

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -119,6 +119,10 @@ def test_report_viewers_include_section_filter_controls():
 
         assert 'id="section-filter"' in viewer
         assert 'id="section-filter-count"' in viewer
+        assert (
+            'id="section-filter-count" role="status" aria-live="polite" aria-atomic="true"'
+            in viewer
+        )
         assert 'id="section-filter-empty"' in viewer
         assert 'id="section-filter-clear-empty"' in viewer
         assert "filterSections" in viewer


### PR DESCRIPTION
## Summary

- mark the report section filter count as a polite status region
- keep the duplicated root and docs viewers aligned
- add a focused viewer guard

Closes #91

## Validation

- `uv run pytest tests/test_report_viewer_security.py -q`
- `bash scripts/local_validation.sh`
