### PR TITLE
Expose archive filter count as status

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -372,7 +372,7 @@
             <input id="archive-filter" type="search" autocomplete="off" placeholder="Search CVEs, vendors, products, or campaigns" />
             <div class="archive-topic-filters" id="archive-topic-filters" aria-label="Filter by report topic"></div>
             <button class="archive-clear-filters" id="archive-clear-filters" type="button" disabled>Clear filters</button>
-            <div class="archive-count" id="archive-count">1 report available</div>
+            <div class="archive-count" id="archive-count" role="status" aria-live="polite" aria-atomic="true">1 report available</div>
             <div class="archive-filter-summary" id="archive-filter-summary" aria-live="polite">Showing all archived reports.</div>
         </div>
         <section class="archive-results" id="archive-results" aria-label="Available reports">

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -355,6 +355,10 @@ def test_report_archive_route_has_static_index():
     assert 'id="archive-summary"' in archive
     assert 'href="#archive-summary"' in archive
     assert 'id="archive-count"' in archive
+    assert (
+        'id="archive-count" role="status" aria-live="polite" aria-atomic="true"'
+        in archive
+    )
     assert 'href="#archive-results"' in archive
     assert 'class="archive-results" id="archive-results"' in archive
     assert 'id="archive-empty"' in archive


### PR DESCRIPTION
## Summary

- mark the archive filter result count as a polite status region
- add a focused archive viewer guard

Closes #93

## Validation

- `uv run pytest tests/test_report_viewer_security.py -q`
- `bash scripts/local_validation.sh`
