### PR TITLE
Expose archive filter summary as status

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -373,7 +373,7 @@
             <div class="archive-topic-filters" id="archive-topic-filters" aria-label="Filter by report topic"></div>
             <button class="archive-clear-filters" id="archive-clear-filters" type="button" disabled>Clear filters</button>
             <div class="archive-count" id="archive-count" role="status" aria-live="polite" aria-atomic="true">1 report available</div>
-            <div class="archive-filter-summary" id="archive-filter-summary" aria-live="polite">Showing all archived reports.</div>
+            <div class="archive-filter-summary" id="archive-filter-summary" role="status" aria-live="polite" aria-atomic="true">Showing all archived reports.</div>
         </div>
         <section class="archive-results" id="archive-results" aria-label="Available reports">
             <div class="archive-list" id="archive-list"></div>

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -418,6 +418,10 @@ def test_report_archive_filter_state_uses_canonical_query_params():
     assert "function writeArchiveQueryState()" in archive
     assert 'id="archive-filter-summary"' in archive
     assert (
+        'id="archive-filter-summary" role="status" aria-live="polite" aria-atomic="true"'
+        in archive
+    )
+    assert (
         "const archiveFilterSummaryEl = document.getElementById('archive-filter-summary')"
         in archive
     )


### PR DESCRIPTION
## Summary

- mark the archive filter summary as a polite atomic status region
- add a focused archive viewer guard

Closes #95

## Validation

- `uv run pytest tests/test_report_viewer_security.py -q`
- `bash scripts/local_validation.sh`
