### PR TITLE
Connect archive filter to results

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -369,7 +369,7 @@
         </nav>
         <div class="archive-filter" id="archive-filter-panel">
             <label for="archive-filter">Filter archived reports</label>
-            <input id="archive-filter" type="search" autocomplete="off" placeholder="Search CVEs, vendors, products, or campaigns" />
+            <input id="archive-filter" type="search" autocomplete="off" aria-controls="archive-results" placeholder="Search CVEs, vendors, products, or campaigns" />
             <div class="archive-topic-filters" id="archive-topic-filters" aria-label="Filter by report topic"></div>
             <button class="archive-clear-filters" id="archive-clear-filters" type="button" disabled>Clear filters</button>
             <div class="archive-count" id="archive-count" role="status" aria-live="polite" aria-atomic="true">1 report available</div>

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -352,6 +352,10 @@ def test_report_archive_route_has_static_index():
     assert "../index.html?report=reports/index.md" in archive
     assert "index.md" in archive
     assert 'id="archive-filter"' in archive
+    assert (
+        'id="archive-filter" type="search" autocomplete="off" aria-controls="archive-results"'
+        in archive
+    )
     assert 'id="archive-summary"' in archive
     assert 'href="#archive-summary"' in archive
     assert 'id="archive-count"' in archive


### PR DESCRIPTION
## Summary

- connect the archive search input to the archive results region
- add a focused archive viewer guard

Closes #97

## Validation

- `uv run pytest tests/test_report_viewer_security.py -q`
- `bash scripts/local_validation.sh`
