### PR TITLE
Connect report filter to results

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -641,7 +641,7 @@
                 <div id="coverage-notes" class="coverage-notes" hidden></div>
                 <div class="section-filter" id="section-filter-panel">
                     <label for="section-filter">Filter report sections</label>
-                    <input id="section-filter" type="search" autocomplete="off" placeholder="Search vulnerabilities, products, actors, or techniques" />
+                    <input id="section-filter" type="search" autocomplete="off" aria-controls="report-results" placeholder="Search vulnerabilities, products, actors, or techniques" />
                     <div class="filter-meta" id="section-filter-count" role="status" aria-live="polite" aria-atomic="true"></div>
                 </div>
                 <section class="report-results" id="report-results" aria-label="Report sections">

--- a/index.html
+++ b/index.html
@@ -641,7 +641,7 @@
                 <div id="coverage-notes" class="coverage-notes" hidden></div>
                 <div class="section-filter" id="section-filter-panel">
                     <label for="section-filter">Filter report sections</label>
-                    <input id="section-filter" type="search" autocomplete="off" placeholder="Search vulnerabilities, products, actors, or techniques" />
+                    <input id="section-filter" type="search" autocomplete="off" aria-controls="report-results" placeholder="Search vulnerabilities, products, actors, or techniques" />
                     <div class="filter-meta" id="section-filter-count" role="status" aria-live="polite" aria-atomic="true"></div>
                 </div>
                 <section class="report-results" id="report-results" aria-label="Report sections">

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -118,6 +118,10 @@ def test_report_viewers_include_section_filter_controls():
         viewer = viewer_path.read_text()
 
         assert 'id="section-filter"' in viewer
+        assert (
+            'id="section-filter" type="search" autocomplete="off" aria-controls="report-results"'
+            in viewer
+        )
         assert 'id="section-filter-count"' in viewer
         assert (
             'id="section-filter-count" role="status" aria-live="polite" aria-atomic="true"'


### PR DESCRIPTION
## Summary
- Connect the report section filter input to the report results region in both static viewer copies.
- Add a focused guard for the viewer contract.

## Motivation
The section filter updates the report results region, so the input should expose that relationship to assistive technology.

## Validation
- `uv run pytest tests/test_report_viewer_security.py -q`
- `bash scripts/local_validation.sh`

Closes #99