### PR TITLE
Connect report filter to count status

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -641,7 +641,7 @@
                 <div id="coverage-notes" class="coverage-notes" hidden></div>
                 <div class="section-filter" id="section-filter-panel">
                     <label for="section-filter">Filter report sections</label>
-                    <input id="section-filter" type="search" autocomplete="off" aria-controls="report-results" placeholder="Search vulnerabilities, products, actors, or techniques" />
+                    <input id="section-filter" type="search" autocomplete="off" aria-controls="report-results" aria-describedby="section-filter-count" placeholder="Search vulnerabilities, products, actors, or techniques" />
                     <div class="filter-meta" id="section-filter-count" role="status" aria-live="polite" aria-atomic="true"></div>
                 </div>
                 <section class="report-results" id="report-results" aria-label="Report sections">

--- a/index.html
+++ b/index.html
@@ -641,7 +641,7 @@
                 <div id="coverage-notes" class="coverage-notes" hidden></div>
                 <div class="section-filter" id="section-filter-panel">
                     <label for="section-filter">Filter report sections</label>
-                    <input id="section-filter" type="search" autocomplete="off" aria-controls="report-results" placeholder="Search vulnerabilities, products, actors, or techniques" />
+                    <input id="section-filter" type="search" autocomplete="off" aria-controls="report-results" aria-describedby="section-filter-count" placeholder="Search vulnerabilities, products, actors, or techniques" />
                     <div class="filter-meta" id="section-filter-count" role="status" aria-live="polite" aria-atomic="true"></div>
                 </div>
                 <section class="report-results" id="report-results" aria-label="Report sections">

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -122,6 +122,7 @@ def test_report_viewers_include_section_filter_controls():
             'id="section-filter" type="search" autocomplete="off" aria-controls="report-results"'
             in viewer
         )
+        assert 'aria-describedby="section-filter-count"' in viewer
         assert 'id="section-filter-count"' in viewer
         assert (
             'id="section-filter-count" role="status" aria-live="polite" aria-atomic="true"'


### PR DESCRIPTION
## Summary
- Connect the report section filter input to the existing result-count status in both static viewer copies.
- Add a focused guard for the viewer contract.

## Motivation
The section filter updates the result count, so the input should expose that status text as its description.

## Validation
- `uv run pytest tests/test_report_viewer_security.py -q`
- `bash scripts/local_validation.sh`

Closes #101