### PR TITLE
Connect archive filter to status summaries

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -369,7 +369,7 @@
         </nav>
         <div class="archive-filter" id="archive-filter-panel">
             <label for="archive-filter">Filter archived reports</label>
-            <input id="archive-filter" type="search" autocomplete="off" aria-controls="archive-results" placeholder="Search CVEs, vendors, products, or campaigns" />
+            <input id="archive-filter" type="search" autocomplete="off" aria-controls="archive-results" aria-describedby="archive-count archive-filter-summary" placeholder="Search CVEs, vendors, products, or campaigns" />
             <div class="archive-topic-filters" id="archive-topic-filters" aria-label="Filter by report topic"></div>
             <button class="archive-clear-filters" id="archive-clear-filters" type="button" disabled>Clear filters</button>
             <div class="archive-count" id="archive-count" role="status" aria-live="polite" aria-atomic="true">1 report available</div>

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -361,6 +361,7 @@ def test_report_archive_route_has_static_index():
         'id="archive-filter" type="search" autocomplete="off" aria-controls="archive-results"'
         in archive
     )
+    assert 'aria-describedby="archive-count archive-filter-summary"' in archive
     assert 'id="archive-summary"' in archive
     assert 'href="#archive-summary"' in archive
     assert 'id="archive-count"' in archive


### PR DESCRIPTION
## Summary
- Connect the archive filter input to the existing count and filter summary status regions.
- Add a focused guard for the archive page contract.

## Motivation
The archive filter updates result status text, so the input should expose those status regions as its description.

## Validation
- `uv run pytest tests/test_report_viewer_security.py -q`
- `bash scripts/local_validation.sh`

Closes #103