### PR TITLE
Connect archive topics to result status

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -435,6 +435,8 @@
             button.classList.add('archive-focus-target');
             button.dataset.topic = topic;
             button.setAttribute('aria-pressed', String(pressed));
+            button.setAttribute('aria-controls', 'archive-results');
+            button.setAttribute('aria-describedby', 'archive-count archive-filter-summary');
             const label = document.createElement('span');
             label.textContent = topic || 'All';
             const count = document.createElement('span');

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -391,6 +391,11 @@ def test_report_archive_route_has_static_index():
     assert 'id="archive-topic-filters"' in archive
     assert "filterArchiveByTopic" in archive
     assert "aria-pressed" in archive
+    assert "button.setAttribute('aria-controls', 'archive-results')" in archive
+    assert (
+        "button.setAttribute('aria-describedby', 'archive-count archive-filter-summary')"
+        in archive
+    )
     assert 'id="archive-clear-filters"' in archive
     assert "clearArchiveFilters" in archive
     assert "archiveClearFiltersEl.disabled" in archive


### PR DESCRIPTION
## Summary
- Connect archive topic filter buttons to the archive results region and existing status text.
- Add a focused guard for the archive page contract.

## Motivation
Topic filters update the visible report list and status summaries, so each button should expose those related regions.

## Validation
- `uv run pytest tests/test_report_viewer_security.py -q`
- `bash scripts/local_validation.sh`

Closes #105