### PR TITLE
Connect archive inline topics to result status

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -646,6 +646,8 @@
                     tag.className = 'archive-tag';
                     tag.classList.add('archive-focus-target');
                     tag.type = 'button';
+                    tag.setAttribute('aria-controls', 'archive-results');
+                    tag.setAttribute('aria-describedby', 'archive-count archive-filter-summary');
                     tag.textContent = topic;
                     tag.addEventListener('click', () => filterArchiveByTopic(topic));
                     tags.appendChild(tag);

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -417,6 +417,11 @@ def test_report_archive_route_has_static_index():
     assert "archiveTagLabel.className = 'archive-tag-label'" in archive
     assert "archiveTagLabel.textContent = 'Topics'" in archive
     assert "tag.type = 'button'" in archive
+    assert "tag.setAttribute('aria-controls', 'archive-results')" in archive
+    assert (
+        "tag.setAttribute('aria-describedby', 'archive-count archive-filter-summary')"
+        in archive
+    )
     assert "filterArchiveByTopic(topic)" in archive
     assert ".archive-focus-target:focus-visible" in archive
     assert "outline: 3px solid #2563eb" in archive


### PR DESCRIPTION
## Summary
- Connect inline archive topic tags to the archive results region and existing status text.
- Add a focused guard for the archive page contract.

## Motivation
Archive card topic tags update the visible report list and status summaries, so each button should expose those related regions.

## Validation
- `uv run pytest tests/test_report_viewer_security.py -q`
- `bash scripts/local_validation.sh`

Closes #107