### PR TITLE
Connect archive clear filters to result status

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -371,7 +371,7 @@
             <label for="archive-filter">Filter archived reports</label>
             <input id="archive-filter" type="search" autocomplete="off" aria-controls="archive-results" aria-describedby="archive-count archive-filter-summary" placeholder="Search CVEs, vendors, products, or campaigns" />
             <div class="archive-topic-filters" id="archive-topic-filters" aria-label="Filter by report topic"></div>
-            <button class="archive-clear-filters" id="archive-clear-filters" type="button" disabled>Clear filters</button>
+            <button class="archive-clear-filters" id="archive-clear-filters" type="button" aria-controls="archive-results" aria-describedby="archive-count archive-filter-summary" disabled>Clear filters</button>
             <div class="archive-count" id="archive-count" role="status" aria-live="polite" aria-atomic="true">1 report available</div>
             <div class="archive-filter-summary" id="archive-filter-summary" role="status" aria-live="polite" aria-atomic="true">Showing all archived reports.</div>
         </div>
@@ -379,7 +379,7 @@
             <div class="archive-list" id="archive-list"></div>
             <div class="archive-empty" id="archive-empty" hidden>
                 <p>No archived reports match that filter.</p>
-                <button class="archive-empty-clear archive-focus-target" id="archive-empty-clear" type="button">Clear filters</button>
+                <button class="archive-empty-clear archive-focus-target" id="archive-empty-clear" type="button" aria-controls="archive-results" aria-describedby="archive-count archive-filter-summary">Clear filters</button>
             </div>
         </section>
     </main>

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -401,8 +401,17 @@ def test_report_archive_route_has_static_index():
     assert "archiveClearFiltersEl.disabled" in archive
     assert 'id="archive-empty-clear"' in archive
     assert (
+        'id="archive-clear-filters" type="button" aria-controls="archive-results"'
+        in archive
+    )
+    assert (
+        'id="archive-empty-clear" type="button" aria-controls="archive-results"'
+        in archive
+    )
+    assert (
         "archiveEmptyClearEl.addEventListener('click', clearArchiveFilters)" in archive
     )
+    assert archive.count('aria-describedby="archive-count archive-filter-summary"') >= 3
     assert "archive-empty-clear archive-focus-target" in archive
     assert "const archiveReports = [" in archive
     assert "renderArchiveReports" in archive


### PR DESCRIPTION
## Summary
- Connect archive clear-filter buttons to the archive results region and existing status text.
- Add a focused guard for the archive page contract.

## Motivation
Clear-filter actions reset the visible report list and status summaries, so each button should expose those related regions.

## Validation
- `uv run pytest tests/test_report_viewer_security.py -q`
- `bash scripts/local_validation.sh`

Closes #109