### PR TITLE
Connect report section clear to result status

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -647,7 +647,7 @@
                 <section class="report-results" id="report-results" aria-label="Report sections">
                     <div class="section-filter-empty" id="section-filter-empty">
                         <p>No matching report sections.</p>
-                        <button id="section-filter-clear-empty" type="button">Clear filter</button>
+                        <button id="section-filter-clear-empty" type="button" aria-controls="report-results" aria-describedby="section-filter-count">Clear filter</button>
                     </div>
                     <div id="exec" class="exec"></div>
                     <div id="content" class="markdown-body"></div>

--- a/index.html
+++ b/index.html
@@ -647,7 +647,7 @@
                 <section class="report-results" id="report-results" aria-label="Report sections">
                     <div class="section-filter-empty" id="section-filter-empty">
                         <p>No matching report sections.</p>
-                        <button id="section-filter-clear-empty" type="button">Clear filter</button>
+                        <button id="section-filter-clear-empty" type="button" aria-controls="report-results" aria-describedby="section-filter-count">Clear filter</button>
                     </div>
                     <div id="exec" class="exec"></div>
                     <div id="content" class="markdown-body"></div>

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -130,6 +130,11 @@ def test_report_viewers_include_section_filter_controls():
         )
         assert 'id="section-filter-empty"' in viewer
         assert 'id="section-filter-clear-empty"' in viewer
+        assert (
+            'id="section-filter-clear-empty" type="button" aria-controls="report-results"'
+            in viewer
+        )
+        assert 'aria-describedby="section-filter-count">Clear filter</button>' in viewer
         assert "filterSections" in viewer
         assert "buildFilterGroups" in viewer
         assert "flushDirectGroup" in viewer


### PR DESCRIPTION
## Summary
- Connect the report section-filter clear button to the report results region and count status.
- Add a focused guard for both static viewer copies.

## Motivation
The empty-state clear action resets visible report sections and count text, so the button should expose those related regions.

## Validation
- `uv run pytest tests/test_report_viewer_security.py -q`
- `bash scripts/local_validation.sh`

Closes #111