### PR TITLE
Add source evidence table caption

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -434,6 +434,14 @@
             margin-top: 12px;
             font-size: .9rem;
         }
+        .source-evidence-table caption {
+            color: var(--text-secondary);
+            font-size: .78rem;
+            font-weight: 700;
+            padding-bottom: 6px;
+            text-align: left;
+            text-transform: uppercase;
+        }
         .source-evidence-table th,
         .source-evidence-table td {
             border-top: 1px solid var(--border-color);
@@ -1088,7 +1096,10 @@
             const rows = sourceEntries.map(parseSourceAttributionEntry);
             const table = document.createElement('table');
             table.className = 'source-evidence-table';
-            table.innerHTML = `
+            const caption = document.createElement('caption');
+            caption.textContent = 'Source Attribution evidence rows';
+            table.appendChild(caption);
+            table.insertAdjacentHTML('beforeend', `
                 <thead>
                     <tr>
                         <th scope="col">Evidence</th>
@@ -1097,7 +1108,7 @@
                     </tr>
                 </thead>
                 <tbody></tbody>
-            `;
+            `);
             const body = table.querySelector('tbody');
             rows.forEach(row => {
                 const tr = document.createElement('tr');

--- a/index.html
+++ b/index.html
@@ -434,6 +434,14 @@
             margin-top: 12px;
             font-size: .9rem;
         }
+        .source-evidence-table caption {
+            color: var(--text-secondary);
+            font-size: .78rem;
+            font-weight: 700;
+            padding-bottom: 6px;
+            text-align: left;
+            text-transform: uppercase;
+        }
         .source-evidence-table th,
         .source-evidence-table td {
             border-top: 1px solid var(--border-color);
@@ -1088,7 +1096,10 @@
             const rows = sourceEntries.map(parseSourceAttributionEntry);
             const table = document.createElement('table');
             table.className = 'source-evidence-table';
-            table.innerHTML = `
+            const caption = document.createElement('caption');
+            caption.textContent = 'Source Attribution evidence rows';
+            table.appendChild(caption);
+            table.insertAdjacentHTML('beforeend', `
                 <thead>
                     <tr>
                         <th scope="col">Evidence</th>
@@ -1097,7 +1108,7 @@
                     </tr>
                 </thead>
                 <tbody></tbody>
-            `;
+            `);
             const body = table.querySelector('tbody');
             rows.forEach(row => {
                 const tr = document.createElement('tr');

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -605,6 +605,9 @@ def test_report_viewers_render_source_entries_as_evidence_rows():
 
         assert "function parseSourceAttributionEntry(entry)" in viewer
         assert "function renderSourceEvidenceRows(sourceEntries)" in viewer
+        assert "const caption = document.createElement('caption')" in viewer
+        assert "caption.textContent = 'Source Attribution evidence rows'" in viewer
+        assert "table.appendChild(caption)" in viewer
         assert "const titleEl = li.querySelector('strong')" in viewer
         assert "entries.push({ raw, title, attribution })" in viewer
         assert "const titleFromMarkup = entry.title || ''" in viewer


### PR DESCRIPTION
## Summary
- Add a visible caption to the Source Attribution evidence table in both static viewer copies.
- Guard the duplicated viewer contract with the report viewer test suite.

## Motivation
The provenance panel renders Source Attribution entries as a table, so the table should name the evidence rows it contains.

## Validation
- `uv run pytest tests/test_report_viewer_security.py -q`
- `bash scripts/local_validation.sh`

Closes #113
