### PR TITLE
Show source preview entry count

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1055,7 +1055,8 @@
             preview.className = 'source-preview';
 
             const summary = document.createElement('summary');
-            summary.textContent = 'View source entries';
+            const entryLabel = sourceEntries.length === 1 ? 'entry' : 'entries';
+            summary.textContent = `View ${sourceEntries.length} source ${entryLabel}`;
             preview.appendChild(summary);
 
             const sourcePreviewList = document.createElement('ul');

--- a/index.html
+++ b/index.html
@@ -1055,7 +1055,8 @@
             preview.className = 'source-preview';
 
             const summary = document.createElement('summary');
-            summary.textContent = 'View source entries';
+            const entryLabel = sourceEntries.length === 1 ? 'entry' : 'entries';
+            summary.textContent = `View ${sourceEntries.length} source ${entryLabel}`;
             preview.appendChild(summary);
 
             const sourcePreviewList = document.createElement('ul');

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -592,7 +592,15 @@ def test_report_viewers_include_source_provenance_panel():
         assert "renderSourcePreview" in viewer
         assert "source-preview" in viewer
         assert "sourcePreviewList" in viewer
-        assert "entryEl.textContent = entry" in viewer
+        assert (
+            "const entryLabel = sourceEntries.length === 1 ? 'entry' : 'entries'"
+            in viewer
+        )
+        assert (
+            "summary.textContent = `View ${sourceEntries.length} source ${entryLabel}`"
+            in viewer
+        )
+        assert "entryEl.textContent = entry.raw || entry" in viewer
         assert "sourcePreviewList.innerHTML = ''" in viewer
         assert "findSourceAttributionHeading" in viewer
         assert "provenanceEl.hidden = true" in viewer


### PR DESCRIPTION
## Summary
- Include the parsed Source Attribution count in the provenance preview summary.
- Guard the duplicated static viewer contract with the report viewer test suite.

## Motivation
The provenance preview already knows how many source entries it expands, so the summary should expose that count before expansion.

## Validation
- `uv run pytest tests/test_report_viewer_security.py -q`
- `bash scripts/local_validation.sh`

Closes #115
