### PR TITLE
Show no-source provenance notice

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1139,11 +1139,26 @@
             return table;
         }
 
+        function renderNoSourceProvenance() {
+            const notice = document.createElement('div');
+            notice.className = 'provenance-empty';
+
+            const heading = document.createElement('h4');
+            heading.textContent = 'Report Provenance';
+
+            const message = document.createElement('p');
+            message.textContent = 'No source attribution entries were found in this rendered report.';
+
+            notice.append(heading, message);
+            return notice;
+        }
+
         function renderProvenance() {
             const sourceEntries = extractSourceAttributionEntries();
             if (!sourceEntries.length) {
-                provenanceEl.hidden = true;
+                provenanceEl.hidden = false;
                 provenanceEl.innerHTML = '';
+                provenanceEl.appendChild(renderNoSourceProvenance());
                 return;
             }
             provenanceEl.hidden = false;

--- a/index.html
+++ b/index.html
@@ -1139,11 +1139,26 @@
             return table;
         }
 
+        function renderNoSourceProvenance() {
+            const notice = document.createElement('div');
+            notice.className = 'provenance-empty';
+
+            const heading = document.createElement('h4');
+            heading.textContent = 'Report Provenance';
+
+            const message = document.createElement('p');
+            message.textContent = 'No source attribution entries were found in this rendered report.';
+
+            notice.append(heading, message);
+            return notice;
+        }
+
         function renderProvenance() {
             const sourceEntries = extractSourceAttributionEntries();
             if (!sourceEntries.length) {
-                provenanceEl.hidden = true;
+                provenanceEl.hidden = false;
                 provenanceEl.innerHTML = '';
+                provenanceEl.appendChild(renderNoSourceProvenance());
                 return;
             }
             provenanceEl.hidden = false;

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -589,6 +589,13 @@ def test_report_viewers_include_source_provenance_panel():
         assert "n/a" in viewer
         assert "extractSourceAttributionEntries" in viewer
         assert "renderProvenance" in viewer
+        assert "function renderNoSourceProvenance()" in viewer
+        assert "provenance-empty" in viewer
+        assert (
+            "No source attribution entries were found in this rendered report."
+            in viewer
+        )
+        assert "provenanceEl.appendChild(renderNoSourceProvenance())" in viewer
         assert "renderSourcePreview" in viewer
         assert "source-preview" in viewer
         assert "sourcePreviewList" in viewer


### PR DESCRIPTION
## Summary
- Show a provenance notice when a rendered report has no Source Attribution entries.
- Keep the Sources reading-index link available for the no-source provenance state.
- Guard the duplicated static viewer contract with the report viewer test suite.

## Motivation
The coverage panel already reports missing source attribution. The provenance section should expose the same state instead of disappearing from the reading index.

## Validation
- `uv run pytest tests/test_report_viewer_security.py -q`
- `bash scripts/local_validation.sh`

Closes #117