### PR TITLE
Label provenance region

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -644,7 +644,7 @@
                     <a href="#section-filter-panel">Filter</a>
                     <a href="#report-results">Report</a>
                 </nav>
-                <div id="provenance" class="provenance" hidden></div>
+                <div id="provenance" class="provenance" role="region" aria-labelledby="provenance-title" hidden></div>
                 <div id="uncertainty" class="uncertainty" hidden></div>
                 <div id="coverage-notes" class="coverage-notes" hidden></div>
                 <div class="section-filter" id="section-filter-panel">
@@ -1144,6 +1144,7 @@
             notice.className = 'provenance-empty';
 
             const heading = document.createElement('h4');
+            heading.id = 'provenance-title';
             heading.textContent = 'Report Provenance';
 
             const message = document.createElement('p');
@@ -1164,7 +1165,7 @@
             provenanceEl.hidden = false;
             const label = sourceEntries.length === 1 ? 'Source entry' : 'Source entries';
             provenanceEl.innerHTML = `
-                <h4>Report Provenance</h4>
+                <h4 id="provenance-title">Report Provenance</h4>
                 <p>${sourceEntries.length} ${label.toLowerCase()} cited in this report.</p>
                 <div class="provenance-meta">Source entries are rendered from the report's Source Attribution section.</div>
             `;

--- a/index.html
+++ b/index.html
@@ -644,7 +644,7 @@
                     <a href="#section-filter-panel">Filter</a>
                     <a href="#report-results">Report</a>
                 </nav>
-                <div id="provenance" class="provenance" hidden></div>
+                <div id="provenance" class="provenance" role="region" aria-labelledby="provenance-title" hidden></div>
                 <div id="uncertainty" class="uncertainty" hidden></div>
                 <div id="coverage-notes" class="coverage-notes" hidden></div>
                 <div class="section-filter" id="section-filter-panel">
@@ -1144,6 +1144,7 @@
             notice.className = 'provenance-empty';
 
             const heading = document.createElement('h4');
+            heading.id = 'provenance-title';
             heading.textContent = 'Report Provenance';
 
             const message = document.createElement('p');
@@ -1164,7 +1165,7 @@
             provenanceEl.hidden = false;
             const label = sourceEntries.length === 1 ? 'Source entry' : 'Source entries';
             provenanceEl.innerHTML = `
-                <h4>Report Provenance</h4>
+                <h4 id="provenance-title">Report Provenance</h4>
                 <p>${sourceEntries.length} ${label.toLowerCase()} cited in this report.</p>
                 <div class="provenance-meta">Source entries are rendered from the report's Source Attribution section.</div>
             `;

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -581,7 +581,13 @@ def test_report_viewers_include_source_provenance_panel():
         viewer = viewer_path.read_text()
 
         assert 'id="provenance"' in viewer
+        assert (
+            'id="provenance" class="provenance" role="region" '
+            'aria-labelledby="provenance-title" hidden'
+        ) in viewer
         assert "Report Provenance" in viewer
+        assert 'id="provenance-title"' in viewer
+        assert "heading.id = 'provenance-title'" in viewer
         assert "Source entries" in viewer
         assert "isPlaceholderSourceAttributionEntry" in viewer
         assert "no sources were provided" in viewer


### PR DESCRIPTION
## Summary
- Expose the provenance panel as a named region in both static viewer copies.
- Give both provenance render paths the referenced `provenance-title` heading.
- Guard the duplicated viewer contract with focused tests.

## Motivation
The Sources reading-index target should land on a provenance region with a stable accessible name, including the no-source state.

## Validation
- `uv run pytest tests/test_report_viewer_security.py -q`
- `bash scripts/local_validation.sh`

Closes #119