### PR TITLE
Label coverage notes region

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -646,7 +646,7 @@
                 </nav>
                 <div id="provenance" class="provenance" role="region" aria-labelledby="provenance-title" hidden></div>
                 <div id="uncertainty" class="uncertainty" hidden></div>
-                <div id="coverage-notes" class="coverage-notes" hidden></div>
+                <div id="coverage-notes" class="coverage-notes" role="region" aria-labelledby="coverage-notes-title" hidden></div>
                 <div class="section-filter" id="section-filter-panel">
                     <label for="section-filter">Filter report sections</label>
                     <input id="section-filter" type="search" autocomplete="off" aria-controls="report-results" aria-describedby="section-filter-count" placeholder="Search vulnerabilities, products, actors, or techniques" />
@@ -1249,6 +1249,7 @@
             coverageNotesEl.hidden = false;
             coverageNotesEl.innerHTML = '';
             const heading = document.createElement('h4');
+            heading.id = 'coverage-notes-title';
             heading.textContent = 'Report Coverage';
             const summary = document.createElement('div');
             summary.className = 'coverage-summary';

--- a/index.html
+++ b/index.html
@@ -646,7 +646,7 @@
                 </nav>
                 <div id="provenance" class="provenance" role="region" aria-labelledby="provenance-title" hidden></div>
                 <div id="uncertainty" class="uncertainty" hidden></div>
-                <div id="coverage-notes" class="coverage-notes" hidden></div>
+                <div id="coverage-notes" class="coverage-notes" role="region" aria-labelledby="coverage-notes-title" hidden></div>
                 <div class="section-filter" id="section-filter-panel">
                     <label for="section-filter">Filter report sections</label>
                     <input id="section-filter" type="search" autocomplete="off" aria-controls="report-results" aria-describedby="section-filter-count" placeholder="Search vulnerabilities, products, actors, or techniques" />
@@ -1249,6 +1249,7 @@
             coverageNotesEl.hidden = false;
             coverageNotesEl.innerHTML = '';
             const heading = document.createElement('h4');
+            heading.id = 'coverage-notes-title';
             heading.textContent = 'Report Coverage';
             const summary = document.createElement('div');
             summary.className = 'coverage-summary';

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -701,7 +701,12 @@ def test_report_viewers_include_coverage_notes_panel():
         viewer = viewer_path.read_text()
 
         assert 'id="coverage-notes"' in viewer
+        assert (
+            'id="coverage-notes" class="coverage-notes" role="region" '
+            'aria-labelledby="coverage-notes-title" hidden'
+        ) in viewer
         assert "Report Coverage" in viewer
+        assert "heading.id = 'coverage-notes-title'" in viewer
         assert "renderCoverageNotes" in viewer
         assert "buildCoverageNote" in viewer
         assert "buildCoverageSummaryChip" in viewer


### PR DESCRIPTION
## Summary
- Expose the coverage notes panel as a named region in both static viewer copies.
- Give the rendered coverage heading the referenced `coverage-notes-title` ID.
- Guard the duplicated viewer contract with focused tests.

## Motivation
The Coverage reading-index target should land on a region with a stable accessible name.

## Validation
- `uv run pytest tests/test_report_viewer_security.py -q`
- `bash scripts/local_validation.sh`

Closes #121