### PR TITLE
Label uncertainty region

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -645,7 +645,7 @@
                     <a href="#report-results">Report</a>
                 </nav>
                 <div id="provenance" class="provenance" role="region" aria-labelledby="provenance-title" hidden></div>
-                <div id="uncertainty" class="uncertainty" hidden></div>
+                <div id="uncertainty" class="uncertainty" role="region" aria-labelledby="uncertainty-title" hidden></div>
                 <div id="coverage-notes" class="coverage-notes" role="region" aria-labelledby="coverage-notes-title" hidden></div>
                 <div class="section-filter" id="section-filter-panel">
                     <label for="section-filter">Filter report sections</label>
@@ -1203,7 +1203,7 @@
             uncertaintyEl.hidden = false;
             const label = signalCount === 1 ? 'uncertainty signal' : 'uncertainty signals';
             uncertaintyEl.innerHTML = `
-                <h4>Uncertainty Signals</h4>
+                <h4 id="uncertainty-title">Uncertainty Signals</h4>
                 <p>${signalCount} ${label} detected in this report.</p>
                 <div class="uncertainty-meta">Counted from report wording such as unknown, suspected, likely, possible, potential, or could.</div>
             `;

--- a/index.html
+++ b/index.html
@@ -645,7 +645,7 @@
                     <a href="#report-results">Report</a>
                 </nav>
                 <div id="provenance" class="provenance" role="region" aria-labelledby="provenance-title" hidden></div>
-                <div id="uncertainty" class="uncertainty" hidden></div>
+                <div id="uncertainty" class="uncertainty" role="region" aria-labelledby="uncertainty-title" hidden></div>
                 <div id="coverage-notes" class="coverage-notes" role="region" aria-labelledby="coverage-notes-title" hidden></div>
                 <div class="section-filter" id="section-filter-panel">
                     <label for="section-filter">Filter report sections</label>
@@ -1203,7 +1203,7 @@
             uncertaintyEl.hidden = false;
             const label = signalCount === 1 ? 'uncertainty signal' : 'uncertainty signals';
             uncertaintyEl.innerHTML = `
-                <h4>Uncertainty Signals</h4>
+                <h4 id="uncertainty-title">Uncertainty Signals</h4>
                 <p>${signalCount} ${label} detected in this report.</p>
                 <div class="uncertainty-meta">Counted from report wording such as unknown, suspected, likely, possible, potential, or could.</div>
             `;

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -681,7 +681,12 @@ def test_report_viewers_include_uncertainty_signal_panel():
         viewer = viewer_path.read_text()
 
         assert 'id="uncertainty"' in viewer
+        assert (
+            'id="uncertainty" class="uncertainty" role="region" '
+            'aria-labelledby="uncertainty-title" hidden'
+        ) in viewer
         assert "Uncertainty Signals" in viewer
+        assert 'id="uncertainty-title"' in viewer
         assert "countUncertaintySignals" in viewer
         assert "renderUncertaintySignals" in viewer
         assert "getVisibleReportText" in viewer


### PR DESCRIPTION
## Summary
- Expose the uncertainty panel as a named region in both static viewer copies.
- Give the rendered Uncertainty Signals heading the referenced `uncertainty-title` ID.
- Guard the duplicated viewer contract with focused tests.

## Motivation
The Uncertainty reading-index target should land on a region with a stable accessible name when uncertainty signals are present.

## Validation
- `uv run pytest tests/test_report_viewer_security.py -q`
- `bash scripts/local_validation.sh`

Closes #123