### PR TITLE
Label report results region

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -652,7 +652,7 @@
                     <input id="section-filter" type="search" autocomplete="off" aria-controls="report-results" aria-describedby="section-filter-count" placeholder="Search vulnerabilities, products, actors, or techniques" />
                     <div class="filter-meta" id="section-filter-count" role="status" aria-live="polite" aria-atomic="true"></div>
                 </div>
-                <section class="report-results" id="report-results" aria-label="Report sections">
+                <section class="report-results" id="report-results" role="region" aria-label="Report sections">
                     <div class="section-filter-empty" id="section-filter-empty">
                         <p>No matching report sections.</p>
                         <button id="section-filter-clear-empty" type="button" aria-controls="report-results" aria-describedby="section-filter-count">Clear filter</button>

--- a/index.html
+++ b/index.html
@@ -652,7 +652,7 @@
                     <input id="section-filter" type="search" autocomplete="off" aria-controls="report-results" aria-describedby="section-filter-count" placeholder="Search vulnerabilities, products, actors, or techniques" />
                     <div class="filter-meta" id="section-filter-count" role="status" aria-live="polite" aria-atomic="true"></div>
                 </div>
-                <section class="report-results" id="report-results" aria-label="Report sections">
+                <section class="report-results" id="report-results" role="region" aria-label="Report sections">
                     <div class="section-filter-empty" id="section-filter-empty">
                         <p>No matching report sections.</p>
                         <button id="section-filter-clear-empty" type="button" aria-controls="report-results" aria-describedby="section-filter-count">Clear filter</button>

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -166,6 +166,9 @@ def test_report_viewers_expose_static_reading_index():
         assert 'href="#report-results"' in viewer
         assert 'id="section-filter-panel"' in viewer
         assert 'id="report-results"' in viewer
+        assert (
+            'id="report-results" role="region" aria-label="Report sections"' in viewer
+        )
         assert 'aria-label="Report sections"' in viewer
         assert 'id="content"' in viewer
         assert viewer.index('id="report-results"') < viewer.index(


### PR DESCRIPTION
## Summary
- Expose the rendered report results wrapper as a named region in both static viewer copies.
- Guard the duplicated viewer contract with a focused report-viewer test.

## Motivation
The Report reading-index target should land on a region with a stable accessible name.

## Validation
- `uv run pytest tests/test_report_viewer_security.py -q`
- `bash scripts/local_validation.sh`

Closes #125