### PR TITLE
Resolve logo asset path for previews

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SentryInsight Exploitation Report</title>
-    <link rel="icon" type="image/png" href="/SentryInsight/assets/logo.png">
-    <link rel="shortcut icon" type="image/png" href="/SentryInsight/assets/logo.png">
+    <link rel="icon" type="image/png" data-logo-asset="icon">
+    <link rel="shortcut icon" type="image/png" data-logo-asset="shortcut-icon">
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown.min.css">
@@ -615,7 +615,7 @@
     <div class="app">
         <header class="topbar">
             <div class="brand">
-                <img src="/SentryInsight/assets/logo.png" alt="SentryInsight" />
+                <img data-logo-asset="header-logo" alt="SentryInsight" />
                 <div>
                     <div class="title">SentryInsight</div>
                     <div class="subtitle">Exploitation Intelligence Report</div>
@@ -666,6 +666,7 @@
 
     <script>
         const layoutEl = document.querySelector('.layout');
+        const logoAssetEls = document.querySelectorAll('[data-logo-asset]');
         const contentEl = document.getElementById('content');
         const tocEl = document.getElementById('toc-list');
         const tocAsideEl = document.getElementById('toc');
@@ -687,7 +688,25 @@
         const sectionFilterEmptyEl = document.getElementById('section-filter-empty');
         const sectionFilterClearEmptyEl = document.getElementById('section-filter-clear-empty');
 
+        function resolveLogoAssetPath() {
+            return location.pathname.includes('/docs/')
+                ? '../assets/logo.png'
+                : 'assets/logo.png';
+        }
+
+        function applyLogoAssetPath() {
+            const logoPath = resolveLogoAssetPath();
+            logoAssetEls.forEach((element) => {
+                if (element.tagName === 'LINK') {
+                    element.href = logoPath;
+                } else {
+                    element.src = logoPath;
+                }
+            });
+        }
+
         // Initial UI state
+        applyLogoAssetPath();
         contentEl.innerHTML = '<div class="loading">Loading exploitation report...</div>';
         const preferDark = localStorage.getItem('sentryinsight:theme') === 'dark' || (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
         if (preferDark) document.body.classList.add('dark');

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SentryInsight Exploitation Report</title>
-    <link rel="icon" type="image/png" href="/SentryInsight/assets/logo.png">
-    <link rel="shortcut icon" type="image/png" href="/SentryInsight/assets/logo.png">
+    <link rel="icon" type="image/png" data-logo-asset="icon">
+    <link rel="shortcut icon" type="image/png" data-logo-asset="shortcut-icon">
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown.min.css">
@@ -615,7 +615,7 @@
     <div class="app">
         <header class="topbar">
             <div class="brand">
-                <img src="/SentryInsight/assets/logo.png" alt="SentryInsight" />
+                <img data-logo-asset="header-logo" alt="SentryInsight" />
                 <div>
                     <div class="title">SentryInsight</div>
                     <div class="subtitle">Exploitation Intelligence Report</div>
@@ -666,6 +666,7 @@
 
     <script>
         const layoutEl = document.querySelector('.layout');
+        const logoAssetEls = document.querySelectorAll('[data-logo-asset]');
         const contentEl = document.getElementById('content');
         const tocEl = document.getElementById('toc-list');
         const tocAsideEl = document.getElementById('toc');
@@ -687,7 +688,25 @@
         const sectionFilterEmptyEl = document.getElementById('section-filter-empty');
         const sectionFilterClearEmptyEl = document.getElementById('section-filter-clear-empty');
 
+        function resolveLogoAssetPath() {
+            return location.pathname.includes('/docs/')
+                ? '../assets/logo.png'
+                : 'assets/logo.png';
+        }
+
+        function applyLogoAssetPath() {
+            const logoPath = resolveLogoAssetPath();
+            logoAssetEls.forEach((element) => {
+                if (element.tagName === 'LINK') {
+                    element.href = logoPath;
+                } else {
+                    element.src = logoPath;
+                }
+            });
+        }
+
         // Initial UI state
+        applyLogoAssetPath();
         contentEl.innerHTML = '<div class="loading">Loading exploitation report...</div>';
         const preferDark = localStorage.getItem('sentryinsight:theme') === 'dark' || (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
         if (preferDark) document.body.classList.add('dark');

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -204,6 +204,21 @@ def test_report_viewers_expose_static_reading_index():
         assert "Report" in viewer
 
 
+def test_report_viewers_resolve_logo_assets_without_project_path_lock():
+    for viewer_path in REPORT_VIEWERS:
+        viewer = viewer_path.read_text()
+
+        assert "/SentryInsight/assets/logo.png" not in viewer
+        assert 'data-logo-asset="icon"' in viewer
+        assert 'data-logo-asset="shortcut-icon"' in viewer
+        assert 'data-logo-asset="header-logo"' in viewer
+        assert "function resolveLogoAssetPath()" in viewer
+        assert "function applyLogoAssetPath()" in viewer
+        assert "location.pathname.includes('/docs/')" in viewer
+        assert "const logoPath = resolveLogoAssetPath()" in viewer
+        assert "applyLogoAssetPath()" in viewer
+
+
 def test_report_viewers_include_archive_navigation_affordance():
     for viewer_path in REPORT_VIEWERS:
         viewer = viewer_path.read_text()


### PR DESCRIPTION
## Summary
- Resolve report viewer logo and favicon paths from the current page path instead of a hard-coded project path.
- Guard the duplicated viewer contract with a focused test.

## Motivation
Local previews should load the checked-in logo asset without relying on the project-page URL prefix.

## Validation
- `uv run pytest tests/test_report_viewer_security.py -q`
- `bash scripts/local_validation.sh`

Closes #127