### PR TITLE
Label report filter region

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -647,8 +647,8 @@
                 <div id="provenance" class="provenance" role="region" aria-labelledby="provenance-title" hidden></div>
                 <div id="uncertainty" class="uncertainty" role="region" aria-labelledby="uncertainty-title" hidden></div>
                 <div id="coverage-notes" class="coverage-notes" role="region" aria-labelledby="coverage-notes-title" hidden></div>
-                <div class="section-filter" id="section-filter-panel">
-                    <label for="section-filter">Filter report sections</label>
+                <div class="section-filter" id="section-filter-panel" role="region" aria-labelledby="section-filter-title">
+                    <label id="section-filter-title" for="section-filter">Filter report sections</label>
                     <input id="section-filter" type="search" autocomplete="off" aria-controls="report-results" aria-describedby="section-filter-count" placeholder="Search vulnerabilities, products, actors, or techniques" />
                     <div class="filter-meta" id="section-filter-count" role="status" aria-live="polite" aria-atomic="true"></div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -647,8 +647,8 @@
                 <div id="provenance" class="provenance" role="region" aria-labelledby="provenance-title" hidden></div>
                 <div id="uncertainty" class="uncertainty" role="region" aria-labelledby="uncertainty-title" hidden></div>
                 <div id="coverage-notes" class="coverage-notes" role="region" aria-labelledby="coverage-notes-title" hidden></div>
-                <div class="section-filter" id="section-filter-panel">
-                    <label for="section-filter">Filter report sections</label>
+                <div class="section-filter" id="section-filter-panel" role="region" aria-labelledby="section-filter-title">
+                    <label id="section-filter-title" for="section-filter">Filter report sections</label>
                     <input id="section-filter" type="search" autocomplete="off" aria-controls="report-results" aria-describedby="section-filter-count" placeholder="Search vulnerabilities, products, actors, or techniques" />
                     <div class="filter-meta" id="section-filter-count" role="status" aria-live="polite" aria-atomic="true"></div>
                 </div>

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -165,6 +165,11 @@ def test_report_viewers_expose_static_reading_index():
         assert 'href="#section-filter-panel"' in viewer
         assert 'href="#report-results"' in viewer
         assert 'id="section-filter-panel"' in viewer
+        assert (
+            'id="section-filter-panel" role="region" '
+            'aria-labelledby="section-filter-title"' in viewer
+        )
+        assert 'id="section-filter-title" for="section-filter"' in viewer
         assert 'id="report-results"' in viewer
         assert (
             'id="report-results" role="region" aria-label="Report sections"' in viewer


### PR DESCRIPTION
## Summary
- Expose the report section filter panel as a named region in both static viewer copies.
- Use the existing filter label as the region name and guard the duplicated viewer contract with a focused test.

## Motivation
The Filter reading-index target should land on a region with a stable accessible name.

## Validation
- `uv run pytest tests/test_report_viewer_security.py -q`
- `bash scripts/local_validation.sh`

Closes #129