### PR TITLE
Reject malformed report list items

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -152,4 +152,4 @@ The current threat landscape reflects an exceptionally dangerous convergence of 
 
 ## Threat Actor Activities
 
-- **FishMonger
+- **FishMonger**: China-nexus advanced persistent threat group observed deploying a Windows variant of the SprySOCKS backdoor and abusing legitimate Windows kernel drivers for stealth.

--- a/index.md
+++ b/index.md
@@ -152,4 +152,4 @@ The current threat landscape reflects an exceptionally dangerous convergence of 
 
 ## Threat Actor Activities
 
-- **FishMonger
+- **FishMonger**: China-nexus advanced persistent threat group observed deploying a Windows variant of the SprySOCKS backdoor and abusing legitimate Windows kernel drivers for stealth.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "langchain>=0.1.0",
     "langchain-core",
     "langgraph>=0.0.20",
+    "markdown-it-py>=4.2.0",
     "mcp-python>=0.1.0",
     "pydantic>=2.0.0",
     "pydub",

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -543,17 +543,17 @@ def inline_token_starts_with_strong(token) -> bool:
 
 def text_after_first_strong_token(token) -> str:
     strong_depth = 0
-    found_first_strong = False
+    label_closed = False
     output: list[str] = []
     for child in token.children or []:
-        if child.type == "strong_open":
+        if not label_closed and child.type == "strong_open":
             strong_depth += 1
-            found_first_strong = True
             continue
-        if child.type == "strong_close" and strong_depth:
+        if not label_closed and child.type == "strong_close" and strong_depth:
             strong_depth -= 1
+            label_closed = strong_depth == 0
             continue
-        if found_first_strong and strong_depth == 0:
+        if label_closed:
             output.append(child.content)
 
     return "".join(output).strip()

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -508,7 +508,7 @@ def has_malformed_bold_list_item(markdown: str) -> bool:
             continue
 
         item_text = collect_list_item_text(lines, index, item)
-        closing_marker_index = find_unescaped_strong_marker(
+        closing_marker_index = find_list_label_closing_marker(
             item_text, len(STRONG_MARKER)
         )
         if closing_marker_index is None:
@@ -563,7 +563,7 @@ def has_indented_list_continuation(lines: list[str], index: int) -> bool:
     return False
 
 
-def find_unescaped_strong_marker(markdown: str, start: int = 0) -> int | None:
+def find_list_label_closing_marker(markdown: str, start: int = 0) -> int | None:
     cursor = start
     while cursor < len(markdown):
         if markdown[cursor] == "`" and not has_odd_backslash_escape(markdown, cursor):
@@ -585,11 +585,21 @@ def find_unescaped_strong_marker(markdown: str, start: int = 0) -> int | None:
         if markdown.startswith(STRONG_MARKER, cursor) and not has_odd_backslash_escape(
             markdown, cursor
         ):
-            return cursor
+            remaining_text = markdown[cursor + len(STRONG_MARKER) :].lstrip()
+            if has_plausible_list_label_suffix(remaining_text):
+                return cursor
+            cursor += len(STRONG_MARKER)
+            continue
 
         cursor += 1
 
     return None
+
+
+def has_plausible_list_label_suffix(suffix: str) -> bool:
+    if not suffix:
+        return True
+    return suffix[0] in ":;-.,()"
 
 
 def find_closing_inline_code_delimiter(

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -6,6 +6,8 @@ from html.parser import HTMLParser
 import re
 from typing import Iterable, List
 
+from markdown_it import MarkdownIt
+
 REQUIRED_SECTIONS = (
     "# Exploitation Report",
     "## Active Exploitation Details",
@@ -53,6 +55,7 @@ HTML_EVENT_ATTRIBUTE_PATTERN = re.compile(r"^on[a-z0-9_-]+$", re.IGNORECASE)
 LIST_ITEM_PATTERN = re.compile(r"^[ \t]{0,3}(?:[-+*]|\d+[.)])\s+")
 NESTED_LIST_ITEM_PATTERN = re.compile(r"^[ \t]*(?:[-+*]|\d+[.)])\s+")
 STRONG_MARKER = "**"
+MARKDOWN_PARSER = MarkdownIt("commonmark")
 HTML_BLOCK_OPEN_PATTERN = re.compile(
     r"^<(?P<tag>[A-Za-z][A-Za-z0-9:-]*)(?:\s|>|/)",
     re.IGNORECASE,
@@ -497,28 +500,90 @@ def normalize_markdown_escapes(markdown: str) -> str:
 def has_malformed_bold_list_item(markdown: str) -> bool:
     """Return True for list items that are only a broken or empty bold label."""
     searchable_markdown = strip_markdown_block_code(markdown)
-    lines = searchable_markdown.splitlines()
-    for index, line in enumerate(lines):
-        list_item_match = NESTED_LIST_ITEM_PATTERN.match(line)
-        if not list_item_match:
+    tokens = MARKDOWN_PARSER.parse(searchable_markdown)
+    for index, token in enumerate(tokens):
+        if token.type != "inline" or not token.content.lstrip().startswith(
+            STRONG_MARKER
+        ):
             continue
 
-        item = line[list_item_match.end() :].strip()
-        if not item.startswith(STRONG_MARKER):
+        if not is_list_item_inline_token(tokens, index):
             continue
 
-        item_text = collect_list_item_text(lines, index, item)
-        closing_marker_index = find_list_label_closing_marker(
-            item_text, len(STRONG_MARKER)
-        )
-        if closing_marker_index is None:
+        if not inline_token_starts_with_strong(token):
             return True
 
-        remaining_item = item_text[closing_marker_index + len(STRONG_MARKER) :].strip()
+        remaining_text = text_after_first_strong_token(token)
         if not has_meaningful_list_suffix(
-            remaining_item
-        ) and not has_indented_list_continuation(lines, index):
+            remaining_text
+        ) and not list_item_has_nested_list(tokens, index):
             return True
+
+    return False
+
+
+def is_list_item_inline_token(tokens: list, inline_index: int) -> bool:
+    parent_stack: list[str] = []
+    for token in tokens[:inline_index]:
+        if token.type == "list_item_open":
+            parent_stack.append(token.type)
+        elif token.type == "list_item_close" and parent_stack:
+            parent_stack.pop()
+
+    return bool(parent_stack)
+
+
+def inline_token_starts_with_strong(token) -> bool:
+    for child in token.children or []:
+        if child.type == "text" and not child.content:
+            continue
+        return child.type == "strong_open"
+
+    return False
+
+
+def text_after_first_strong_token(token) -> str:
+    strong_depth = 0
+    found_first_strong = False
+    output: list[str] = []
+    for child in token.children or []:
+        if child.type == "strong_open":
+            strong_depth += 1
+            found_first_strong = True
+            continue
+        if child.type == "strong_close" and strong_depth:
+            strong_depth -= 1
+            continue
+        if found_first_strong and strong_depth == 0:
+            output.append(child.content)
+
+    return "".join(output).strip()
+
+
+def list_item_has_nested_list(tokens: list, inline_index: int) -> bool:
+    list_item_depth = 0
+    for token in reversed(tokens[: inline_index + 1]):
+        if token.type == "list_item_close":
+            list_item_depth += 1
+        elif token.type == "list_item_open":
+            if list_item_depth == 0:
+                break
+            list_item_depth -= 1
+
+    nested_list_depth = 0
+    for token in tokens[inline_index + 1 :]:
+        if token.type == "list_item_open":
+            list_item_depth += 1
+        elif token.type == "list_item_close":
+            if list_item_depth == 0:
+                return False
+            list_item_depth -= 1
+        elif token.type in {"bullet_list_open", "ordered_list_open"}:
+            if nested_list_depth == 0:
+                return True
+            nested_list_depth += 1
+        elif token.type in {"bullet_list_close", "ordered_list_close"}:
+            nested_list_depth = max(nested_list_depth - 1, 0)
 
     return False
 

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -506,10 +506,16 @@ def has_malformed_bold_list_item(markdown: str) -> bool:
             return True
 
         remaining_item = item[closing_marker_index + len(STRONG_MARKER) :].strip()
-        if not remaining_item and not has_indented_list_continuation(lines, index):
+        if not has_meaningful_list_suffix(
+            remaining_item
+        ) and not has_indented_list_continuation(lines, index):
             return True
 
     return False
+
+
+def has_meaningful_list_suffix(suffix: str) -> bool:
+    return any(character.isalnum() for character in suffix)
 
 
 def has_indented_list_continuation(lines: list[str], index: int) -> bool:

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -126,9 +126,14 @@ class ActiveContentHTMLParser(HTMLParser):
 
 def strip_markdown_code(markdown: str) -> str:
     """Remove code regions before active-content validation."""
+    without_block_code = strip_markdown_block_code(markdown)
+    return strip_inline_code_spans(without_block_code)
+
+
+def strip_markdown_block_code(markdown: str) -> str:
+    """Remove Markdown code blocks while preserving inline code spans."""
     without_fenced_code = strip_fenced_code_blocks(markdown)
-    without_indented_code = strip_indented_code_blocks(without_fenced_code)
-    return strip_inline_code_spans(without_indented_code)
+    return strip_indented_code_blocks(without_fenced_code)
 
 
 def strip_fenced_code_blocks(markdown: str) -> str:
@@ -490,7 +495,7 @@ def normalize_markdown_escapes(markdown: str) -> str:
 
 def has_malformed_bold_list_item(markdown: str) -> bool:
     """Return True for list items that are only a broken or empty bold label."""
-    searchable_markdown = strip_markdown_code(markdown)
+    searchable_markdown = strip_markdown_block_code(markdown)
     lines = searchable_markdown.splitlines()
     for index, line in enumerate(lines):
         list_item_match = LIST_ITEM_PATTERN.match(line)

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -51,6 +51,7 @@ MARKDOWN_REFERENCE_DESTINATION_PATTERN = re.compile(
 )
 HTML_EVENT_ATTRIBUTE_PATTERN = re.compile(r"^on[a-z0-9_-]+$", re.IGNORECASE)
 LIST_ITEM_PATTERN = re.compile(r"^[ \t]{0,3}(?:[-+*]|\d+[.)])\s+")
+NESTED_LIST_ITEM_PATTERN = re.compile(r"^[ \t]*(?:[-+*]|\d+[.)])\s+")
 STRONG_MARKER = "**"
 HTML_BLOCK_OPEN_PATTERN = re.compile(
     r"^<(?P<tag>[A-Za-z][A-Za-z0-9:-]*)(?:\s|>|/)",
@@ -498,7 +499,7 @@ def has_malformed_bold_list_item(markdown: str) -> bool:
     searchable_markdown = strip_markdown_block_code(markdown)
     lines = searchable_markdown.splitlines()
     for index, line in enumerate(lines):
-        list_item_match = LIST_ITEM_PATTERN.match(line)
+        list_item_match = NESTED_LIST_ITEM_PATTERN.match(line)
         if not list_item_match:
             continue
 

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -507,11 +507,14 @@ def has_malformed_bold_list_item(markdown: str) -> bool:
         if not item.startswith(STRONG_MARKER):
             continue
 
-        closing_marker_index = find_unescaped_strong_marker(item, len(STRONG_MARKER))
+        item_text = collect_list_item_text(lines, index, item)
+        closing_marker_index = find_unescaped_strong_marker(
+            item_text, len(STRONG_MARKER)
+        )
         if closing_marker_index is None:
             return True
 
-        remaining_item = item[closing_marker_index + len(STRONG_MARKER) :].strip()
+        remaining_item = item_text[closing_marker_index + len(STRONG_MARKER) :].strip()
         if not has_meaningful_list_suffix(
             remaining_item
         ) and not has_indented_list_continuation(lines, index):
@@ -522,6 +525,26 @@ def has_malformed_bold_list_item(markdown: str) -> bool:
 
 def has_meaningful_list_suffix(suffix: str) -> bool:
     return any(character.isalnum() for character in suffix)
+
+
+def collect_list_item_text(lines: list[str], index: int, item: str) -> str:
+    item_parts = [item]
+    item_indent = indentation_columns(lines[index])
+    for continuation_line in lines[index + 1 :]:
+        stripped_continuation = continuation_line.strip()
+        if not stripped_continuation:
+            break
+
+        continuation_indent = indentation_columns(continuation_line)
+        if continuation_indent <= item_indent:
+            break
+
+        if NESTED_LIST_ITEM_PATTERN.match(continuation_line):
+            break
+
+        item_parts.append(stripped_continuation)
+
+    return " ".join(item_parts)
 
 
 def has_indented_list_continuation(lines: list[str], index: int) -> bool:

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -499,8 +499,7 @@ def normalize_markdown_escapes(markdown: str) -> str:
 
 def has_malformed_bold_list_item(markdown: str) -> bool:
     """Return True for list items that are only a broken or empty bold label."""
-    searchable_markdown = strip_markdown_block_code(markdown)
-    tokens = MARKDOWN_PARSER.parse(searchable_markdown)
+    tokens = MARKDOWN_PARSER.parse(markdown)
     for index, token in enumerate(tokens):
         if token.type != "inline" or not token.content.lstrip().startswith(
             STRONG_MARKER
@@ -585,6 +584,8 @@ def list_item_has_following_content(tokens: list, inline_index: int) -> bool:
         elif token.type in {"bullet_list_close", "ordered_list_close"}:
             nested_list_depth = max(nested_list_depth - 1, 0)
         elif token.type == "inline" and has_meaningful_list_suffix(token.content):
+            return True
+        elif token.type in {"code_block", "fence"} and token.content.strip():
             return True
 
     return False

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -536,6 +536,8 @@ def inline_token_starts_with_strong(token) -> bool:
     for child in token.children or []:
         if child.type == "text" and not child.content:
             continue
+        if child.type == "em_open":
+            continue
         return child.type == "strong_open"
 
     return False

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -491,7 +491,8 @@ def normalize_markdown_escapes(markdown: str) -> str:
 def has_malformed_bold_list_item(markdown: str) -> bool:
     """Return True for list items that are only a broken or empty bold label."""
     searchable_markdown = strip_markdown_code(markdown)
-    for line in searchable_markdown.splitlines():
+    lines = searchable_markdown.splitlines()
+    for index, line in enumerate(lines):
         list_item_match = LIST_ITEM_PATTERN.match(line)
         if not list_item_match:
             continue
@@ -505,8 +506,23 @@ def has_malformed_bold_list_item(markdown: str) -> bool:
             return True
 
         remaining_item = item[closing_marker_index + len(STRONG_MARKER) :].strip()
-        if not remaining_item:
+        if not remaining_item and not has_indented_list_continuation(lines, index):
             return True
+
+    return False
+
+
+def has_indented_list_continuation(lines: list[str], index: int) -> bool:
+    item_indent = indentation_columns(lines[index])
+    for continuation_line in lines[index + 1 :]:
+        if not continuation_line.strip():
+            continue
+
+        continuation_indent = indentation_columns(continuation_line)
+        if continuation_indent <= item_indent:
+            return False
+
+        return True
 
     return False
 

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -516,7 +516,7 @@ def has_malformed_bold_list_item(markdown: str) -> bool:
         remaining_text = text_after_first_strong_token(token)
         if not has_meaningful_list_suffix(
             remaining_text
-        ) and not list_item_has_nested_list(tokens, index):
+        ) and not list_item_has_following_content(tokens, index):
             return True
 
     return False
@@ -560,7 +560,7 @@ def text_after_first_strong_token(token) -> str:
     return "".join(output).strip()
 
 
-def list_item_has_nested_list(tokens: list, inline_index: int) -> bool:
+def list_item_has_following_content(tokens: list, inline_index: int) -> bool:
     list_item_depth = 0
     for token in reversed(tokens[: inline_index + 1]):
         if token.type == "list_item_close":
@@ -584,6 +584,8 @@ def list_item_has_nested_list(tokens: list, inline_index: int) -> bool:
             nested_list_depth += 1
         elif token.type in {"bullet_list_close", "ordered_list_close"}:
             nested_list_depth = max(nested_list_depth - 1, 0)
+        elif token.type == "inline" and has_meaningful_list_suffix(token.content):
+            return True
 
     return False
 

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -524,7 +524,8 @@ def has_malformed_bold_list_item(markdown: str) -> bool:
 
 
 def has_meaningful_list_suffix(suffix: str) -> bool:
-    return any(character.isalnum() for character in suffix)
+    rendered_suffix = html.unescape(normalize_markdown_escapes(suffix))
+    return any(character.isalnum() for character in rendered_suffix)
 
 
 def collect_list_item_text(lines: list[str], index: int, item: str) -> str:
@@ -564,13 +565,44 @@ def has_indented_list_continuation(lines: list[str], index: int) -> bool:
 
 def find_unescaped_strong_marker(markdown: str, start: int = 0) -> int | None:
     cursor = start
+    while cursor < len(markdown):
+        if markdown[cursor] == "`" and not has_odd_backslash_escape(markdown, cursor):
+            delimiter_length = 1
+            while (
+                cursor + delimiter_length < len(markdown)
+                and markdown[cursor + delimiter_length] == "`"
+            ):
+                delimiter_length += 1
+
+            delimiter = "`" * delimiter_length
+            closing_delimiter_index = find_closing_inline_code_delimiter(
+                markdown, delimiter, cursor + delimiter_length
+            )
+            if closing_delimiter_index != -1:
+                cursor = closing_delimiter_index + delimiter_length
+                continue
+
+        if markdown.startswith(STRONG_MARKER, cursor) and not has_odd_backslash_escape(
+            markdown, cursor
+        ):
+            return cursor
+
+        cursor += 1
+
+    return None
+
+
+def find_closing_inline_code_delimiter(
+    markdown: str, delimiter: str, start: int
+) -> int:
+    cursor = start
     while True:
-        marker_index = markdown.find(STRONG_MARKER, cursor)
-        if marker_index == -1:
-            return None
-        if not has_odd_backslash_escape(markdown, marker_index):
-            return marker_index
-        cursor = marker_index + len(STRONG_MARKER)
+        delimiter_index = markdown.find(delimiter, cursor)
+        if delimiter_index == -1:
+            return -1
+        if not has_odd_backslash_escape(markdown, delimiter_index):
+            return delimiter_index
+        cursor = delimiter_index + len(delimiter)
 
 
 def preserve_markdown_escaped_html(markdown: str) -> str:

--- a/src/core/report_validation.py
+++ b/src/core/report_validation.py
@@ -51,6 +51,7 @@ MARKDOWN_REFERENCE_DESTINATION_PATTERN = re.compile(
 )
 HTML_EVENT_ATTRIBUTE_PATTERN = re.compile(r"^on[a-z0-9_-]+$", re.IGNORECASE)
 LIST_ITEM_PATTERN = re.compile(r"^[ \t]{0,3}(?:[-+*]|\d+[.)])\s+")
+STRONG_MARKER = "**"
 HTML_BLOCK_OPEN_PATTERN = re.compile(
     r"^<(?P<tag>[A-Za-z][A-Za-z0-9:-]*)(?:\s|>|/)",
     re.IGNORECASE,
@@ -487,6 +488,40 @@ def normalize_markdown_escapes(markdown: str) -> str:
     return MARKDOWN_ESCAPE_PATTERN.sub(r"\1", markdown)
 
 
+def has_malformed_bold_list_item(markdown: str) -> bool:
+    """Return True for list items that are only a broken or empty bold label."""
+    searchable_markdown = strip_markdown_code(markdown)
+    for line in searchable_markdown.splitlines():
+        list_item_match = LIST_ITEM_PATTERN.match(line)
+        if not list_item_match:
+            continue
+
+        item = line[list_item_match.end() :].strip()
+        if not item.startswith(STRONG_MARKER):
+            continue
+
+        closing_marker_index = find_unescaped_strong_marker(item, len(STRONG_MARKER))
+        if closing_marker_index is None:
+            return True
+
+        remaining_item = item[closing_marker_index + len(STRONG_MARKER) :].strip()
+        if not remaining_item:
+            return True
+
+    return False
+
+
+def find_unescaped_strong_marker(markdown: str, start: int = 0) -> int | None:
+    cursor = start
+    while True:
+        marker_index = markdown.find(STRONG_MARKER, cursor)
+        if marker_index == -1:
+            return None
+        if not has_odd_backslash_escape(markdown, marker_index):
+            return marker_index
+        cursor = marker_index + len(STRONG_MARKER)
+
+
 def preserve_markdown_escaped_html(markdown: str) -> str:
     lines = markdown.splitlines(keepends=True)
     output: list[str] = []
@@ -741,6 +776,17 @@ def validate_report_content(
             ReportValidationIssue(
                 code="active_content",
                 message="Report contains blocked JavaScript URL.",
+            )
+        )
+
+    if has_malformed_bold_list_item(content):
+        issues.append(
+            ReportValidationIssue(
+                code="malformed_markdown",
+                message=(
+                    "Report contains a malformed bold list item without a "
+                    "description."
+                ),
             )
         )
 

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -115,6 +115,25 @@ class ReportValidationTests(unittest.TestCase):
 
         self.assertEqual(validate_report_content(report), [])
 
+    def test_wrapped_bold_list_label_with_description_passes(self):
+        report = VALID_REPORT.replace(
+            "- **Unknown actor**: Opportunistic exploitation.",
+            "- **Microsoft Defender for Endpoint and Windows Defender\n"
+            "  Antivirus**: Affected versions require mitigation.",
+        )
+
+        self.assertEqual(validate_report_content(report), [])
+
+    def test_nested_bold_marker_does_not_close_broken_parent_label(self):
+        issues = validate_report_content(
+            VALID_REPORT.replace(
+                "- **Unknown actor**: Opportunistic exploitation.",
+                "- **FishMonger\n" "  - **Campaign**: Deployed a Windows backdoor.",
+            )
+        )
+
+        self.assertTrue(any(issue.code == "malformed_markdown" for issue in issues))
+
     def test_bold_heading_with_continuation_list_passes(self):
         report = VALID_REPORT.replace(
             "- **Unknown actor**: Opportunistic exploitation.",

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -68,6 +68,16 @@ class ReportValidationTests(unittest.TestCase):
 
         self.assertTrue(any(issue.code == "malformed_markdown" for issue in issues))
 
+    def test_colon_only_bold_list_item_without_description_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT.replace(
+                "- **Unknown actor**: Opportunistic exploitation.",
+                "- **FishMonger**:",
+            )
+        )
+
+        self.assertTrue(any(issue.code == "malformed_markdown" for issue in issues))
+
     def test_bold_heading_with_continuation_list_passes(self):
         report = VALID_REPORT.replace(
             "- **Unknown actor**: Opportunistic exploitation.",

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -78,6 +78,24 @@ class ReportValidationTests(unittest.TestCase):
 
         self.assertTrue(any(issue.code == "malformed_markdown" for issue in issues))
 
+    def test_punctuation_only_bold_list_item_without_description_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT.replace(
+                "- **Unknown actor**: Opportunistic exploitation.",
+                "- **FishMonger**: --",
+            )
+        )
+
+        self.assertTrue(any(issue.code == "malformed_markdown" for issue in issues))
+
+    def test_inline_code_bold_list_item_description_passes(self):
+        report = VALID_REPORT.replace(
+            "- **Unknown actor**: Opportunistic exploitation.",
+            "- **Example Package**: `@mastra/*`",
+        )
+
+        self.assertEqual(validate_report_content(report), [])
+
     def test_bold_heading_with_continuation_list_passes(self):
         report = VALID_REPORT.replace(
             "- **Unknown actor**: Opportunistic exploitation.",

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -201,6 +201,14 @@ class ReportValidationTests(unittest.TestCase):
 
         self.assertEqual(validate_report_content(report), [])
 
+    def test_bold_heading_with_indented_paragraph_passes(self):
+        report = VALID_REPORT.replace(
+            "- **Unknown actor**: Opportunistic exploitation.",
+            "- **FishMonger**\n\n" "  Deployed a Windows variant of SprySOCKS.",
+        )
+
+        self.assertEqual(validate_report_content(report), [])
+
     def test_source_attribution_report_fixture_validates_expected_rows(self):
         expected_entries = [
             "- **CISA: exploited KEV update**: Example Research - https://example.test/kev",

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -48,6 +48,26 @@ class ReportValidationTests(unittest.TestCase):
     def test_valid_report_passes(self):
         self.assertEqual(validate_report_content(VALID_REPORT), [])
 
+    def test_dangling_bold_list_item_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT.replace(
+                "- **Unknown actor**: Opportunistic exploitation.",
+                "- **FishMonger",
+            )
+        )
+
+        self.assertTrue(any(issue.code == "malformed_markdown" for issue in issues))
+
+    def test_bold_only_list_item_without_description_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT.replace(
+                "- **Unknown actor**: Opportunistic exploitation.",
+                "- **FishMonger**",
+            )
+        )
+
+        self.assertTrue(any(issue.code == "malformed_markdown" for issue in issues))
+
     def test_source_attribution_report_fixture_validates_expected_rows(self):
         expected_entries = [
             "- **CISA: exploited KEV update**: Example Research - https://example.test/kev",

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -198,6 +198,16 @@ class ReportValidationTests(unittest.TestCase):
 
         self.assertTrue(any(issue.code == "malformed_markdown" for issue in issues))
 
+    def test_capitalized_description_emphasis_does_not_close_broken_label(self):
+        issues = validate_report_content(
+            VALID_REPORT.replace(
+                "- **Unknown actor**: Opportunistic exploitation.",
+                "- **FishMonger\n" "  Deployed **SprySOCKS** to targets.",
+            )
+        )
+
+        self.assertTrue(any(issue.code == "malformed_markdown" for issue in issues))
+
     def test_description_emphasis_with_punctuation_does_not_close_broken_label(self):
         issues = validate_report_content(
             VALID_REPORT.replace(

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -68,6 +68,15 @@ class ReportValidationTests(unittest.TestCase):
 
         self.assertTrue(any(issue.code == "malformed_markdown" for issue in issues))
 
+    def test_bold_heading_with_continuation_list_passes(self):
+        report = VALID_REPORT.replace(
+            "- **Unknown actor**: Opportunistic exploitation.",
+            "- **FishMonger**\n"
+            "  - **Campaign**: Deployed a Windows variant of the SprySOCKS backdoor.",
+        )
+
+        self.assertEqual(validate_report_content(report), [])
+
     def test_source_attribution_report_fixture_validates_expected_rows(self):
         expected_entries = [
             "- **CISA: exploited KEV update**: Example Research - https://example.test/kev",

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -209,6 +209,25 @@ class ReportValidationTests(unittest.TestCase):
 
         self.assertEqual(validate_report_content(report), [])
 
+    def test_bold_heading_with_fenced_code_details_passes(self):
+        report = VALID_REPORT.replace(
+            "- **Unknown actor**: Opportunistic exploitation.",
+            "- **FishMonger**\n\n"
+            "  ```powershell\n"
+            "  Start-Process SprySOCKS\n"
+            "  ```",
+        )
+
+        self.assertEqual(validate_report_content(report), [])
+
+    def test_bold_heading_with_indented_code_details_passes(self):
+        report = VALID_REPORT.replace(
+            "- **Unknown actor**: Opportunistic exploitation.",
+            "- **FishMonger**\n\n" "      Start-Process SprySOCKS",
+        )
+
+        self.assertEqual(validate_report_content(report), [])
+
     def test_source_attribution_report_fixture_validates_expected_rows(self):
         expected_entries = [
             "- **CISA: exploited KEV update**: Example Research - https://example.test/kev",

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -104,6 +104,14 @@ class ReportValidationTests(unittest.TestCase):
 
         self.assertEqual(validate_report_content(report), [])
 
+    def test_combined_emphasis_list_label_passes(self):
+        report = VALID_REPORT.replace(
+            "- **Unknown actor**: Opportunistic exploitation.",
+            "- ***Critical***: actively exploited",
+        )
+
+        self.assertEqual(validate_report_content(report), [])
+
     def test_four_space_nested_dangling_bold_list_item_fails(self):
         issues = validate_report_content(
             VALID_REPORT.replace(

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -96,6 +96,14 @@ class ReportValidationTests(unittest.TestCase):
 
         self.assertEqual(validate_report_content(report), [])
 
+    def test_bold_description_after_bold_list_label_passes(self):
+        report = VALID_REPORT.replace(
+            "- **Unknown actor**: Opportunistic exploitation.",
+            "- **Status**: **Active**",
+        )
+
+        self.assertEqual(validate_report_content(report), [])
+
     def test_four_space_nested_dangling_bold_list_item_fails(self):
         issues = validate_report_content(
             VALID_REPORT.replace(

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -134,6 +134,44 @@ class ReportValidationTests(unittest.TestCase):
 
         self.assertTrue(any(issue.code == "malformed_markdown" for issue in issues))
 
+    def test_inline_code_strong_marker_does_not_close_broken_label(self):
+        issues = validate_report_content(
+            VALID_REPORT.replace(
+                "- **Unknown actor**: Opportunistic exploitation.",
+                "- **Package `@scope/**`: affected versions require review.",
+            )
+        )
+
+        self.assertTrue(any(issue.code == "malformed_markdown" for issue in issues))
+
+    def test_inline_code_strong_marker_with_closed_label_passes(self):
+        report = VALID_REPORT.replace(
+            "- **Unknown actor**: Opportunistic exploitation.",
+            "- **Package `@scope/**`**: affected versions require review.",
+        )
+
+        self.assertEqual(validate_report_content(report), [])
+
+    def test_html_entity_punctuation_only_suffix_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT.replace(
+                "- **Unknown actor**: Opportunistic exploitation.",
+                "- **FishMonger**: &mdash;",
+            )
+        )
+
+        self.assertTrue(any(issue.code == "malformed_markdown" for issue in issues))
+
+    def test_numeric_html_entity_punctuation_only_suffix_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT.replace(
+                "- **Unknown actor**: Opportunistic exploitation.",
+                "- **FishMonger**: &#8212;",
+            )
+        )
+
+        self.assertTrue(any(issue.code == "malformed_markdown" for issue in issues))
+
     def test_bold_heading_with_continuation_list_passes(self):
         report = VALID_REPORT.replace(
             "- **Unknown actor**: Opportunistic exploitation.",

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -182,6 +182,16 @@ class ReportValidationTests(unittest.TestCase):
 
         self.assertTrue(any(issue.code == "malformed_markdown" for issue in issues))
 
+    def test_description_emphasis_with_punctuation_does_not_close_broken_label(self):
+        issues = validate_report_content(
+            VALID_REPORT.replace(
+                "- **Unknown actor**: Opportunistic exploitation.",
+                "- **FishMonger\n" "  deployed **SprySOCKS**: backdoor",
+            )
+        )
+
+        self.assertTrue(any(issue.code == "malformed_markdown" for issue in issues))
+
     def test_bold_heading_with_continuation_list_passes(self):
         report = VALID_REPORT.replace(
             "- **Unknown actor**: Opportunistic exploitation.",

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -96,6 +96,25 @@ class ReportValidationTests(unittest.TestCase):
 
         self.assertEqual(validate_report_content(report), [])
 
+    def test_four_space_nested_dangling_bold_list_item_fails(self):
+        issues = validate_report_content(
+            VALID_REPORT.replace(
+                "- **Unknown actor**: Opportunistic exploitation.",
+                "- **Parent actor**: Coordinated exploitation.\n" "    - **FishMonger",
+            )
+        )
+
+        self.assertTrue(any(issue.code == "malformed_markdown" for issue in issues))
+
+    def test_four_space_nested_bold_list_item_with_description_passes(self):
+        report = VALID_REPORT.replace(
+            "- **Unknown actor**: Opportunistic exploitation.",
+            "- **Parent actor**: Coordinated exploitation.\n"
+            "    - **FishMonger**: Deployed a Windows backdoor.",
+        )
+
+        self.assertEqual(validate_report_content(report), [])
+
     def test_bold_heading_with_continuation_list_passes(self):
         report = VALID_REPORT.replace(
             "- **Unknown actor**: Opportunistic exploitation.",

--- a/tests/test_report_validation.py
+++ b/tests/test_report_validation.py
@@ -172,6 +172,16 @@ class ReportValidationTests(unittest.TestCase):
 
         self.assertTrue(any(issue.code == "malformed_markdown" for issue in issues))
 
+    def test_description_emphasis_does_not_close_broken_label(self):
+        issues = validate_report_content(
+            VALID_REPORT.replace(
+                "- **Unknown actor**: Opportunistic exploitation.",
+                "- **FishMonger\n" "  deployed **SprySOCKS** to targets.",
+            )
+        )
+
+        self.assertTrue(any(issue.code == "malformed_markdown" for issue in issues))
+
     def test_bold_heading_with_continuation_list_passes(self):
         report = VALID_REPORT.replace(
             "- **Unknown actor**: Opportunistic exploitation.",

--- a/uv.lock
+++ b/uv.lock
@@ -589,6 +589,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687 },
+]
+
+[[package]]
 name = "mcp"
 version = "1.28.0"
 source = { registry = "https://pypi.org/simple" }
@@ -623,6 +635,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e7/66/b6e5311c793b25b19ac9177bfbbabca867c1beb61b2cc813aa031574370d/mcp_python-0.1.4.tar.gz", hash = "sha256:0a85ed659141126cc115da90fb139c542a9dbd0c107bc3273c3e8e8f23d8b6b1", size = 15556 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/5f/4d429de941b7b89fcf30940f4199055e334088f83729af904d141850b375/mcp_python-0.1.4-py3-none-any.whl", hash = "sha256:9c86bc3017c7317a4980dab2a8301fc58389c44dd8c0bd9a65832f9c3870d6b8", size = 5780 },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
 ]
 
 [[package]]
@@ -1421,6 +1442,7 @@ dependencies = [
     { name = "langchain" },
     { name = "langchain-core" },
     { name = "langgraph" },
+    { name = "markdown-it-py" },
     { name = "mcp-python" },
     { name = "pydantic" },
     { name = "pydub" },
@@ -1444,6 +1466,7 @@ requires-dist = [
     { name = "langchain", specifier = ">=0.1.0" },
     { name = "langchain-core" },
     { name = "langgraph", specifier = ">=0.0.20" },
+    { name = "markdown-it-py", specifier = ">=4.2.0" },
     { name = "mcp-python", specifier = ">=0.1.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydub" },


### PR DESCRIPTION
## Summary
- Reject generated report list items that contain a broken or descriptionless bold label.
- Repair the current Threat Actor Activities FishMonger entry in both published markdown copies.

## Motivation
Generated reports should fail validation when a list item is truncated to a bold label instead of publishing malformed markdown.

## Validation
- `uv run python -m pytest tests/test_report_validation.py -q -p no:cacheprovider`
- `uv run python -B scripts/validate_report.py index.md`
- `uv run python -B scripts/validate_report.py docs/index.md`
- `bash scripts/local_validation.sh`

Closes #131