### PR TITLE
Label archive filter region

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -367,8 +367,8 @@
             <a class="archive-focus-target" href="#archive-filter-panel">Filter</a>
             <a class="archive-focus-target" href="#archive-results">Reports</a>
         </nav>
-        <div class="archive-filter" id="archive-filter-panel">
-            <label for="archive-filter">Filter archived reports</label>
+        <div class="archive-filter" id="archive-filter-panel" role="region" aria-labelledby="archive-filter-title">
+            <label id="archive-filter-title" for="archive-filter">Filter archived reports</label>
             <input id="archive-filter" type="search" autocomplete="off" aria-controls="archive-results" aria-describedby="archive-count archive-filter-summary" placeholder="Search CVEs, vendors, products, or campaigns" />
             <div class="archive-topic-filters" id="archive-topic-filters" aria-label="Filter by report topic"></div>
             <button class="archive-clear-filters" id="archive-clear-filters" type="button" aria-controls="archive-results" aria-describedby="archive-count archive-filter-summary" disabled>Clear filters</button>

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -510,6 +510,11 @@ def test_report_archive_exposes_static_section_index():
     assert 'href="#archive-results"' in archive
     assert 'id="archive-summary"' in archive
     assert 'id="archive-filter-panel"' in archive
+    assert (
+        'id="archive-filter-panel" role="region" '
+        'aria-labelledby="archive-filter-title"' in archive
+    )
+    assert 'id="archive-filter-title" for="archive-filter"' in archive
     assert 'id="archive-results"' in archive
     assert 'id="archive-list"' in archive
     assert "#archive-summary, #archive-filter-panel, #archive-results" in archive


### PR DESCRIPTION
## Summary
- Expose the archive filter panel as a named region.
- Use the existing archive filter label as the region name and guard the static archive contract with a focused test.

## Motivation
The archive section-index Filter target should land on a region with a stable accessible name.

## Validation
- `uv run pytest tests/test_report_viewer_security.py -q`
- `bash scripts/local_validation.sh`

Closes #133