### PR TITLE
Label archive results region

### DIFF
--- a/docs/reports/index.html
+++ b/docs/reports/index.html
@@ -375,7 +375,7 @@
             <div class="archive-count" id="archive-count" role="status" aria-live="polite" aria-atomic="true">1 report available</div>
             <div class="archive-filter-summary" id="archive-filter-summary" role="status" aria-live="polite" aria-atomic="true">Showing all archived reports.</div>
         </div>
-        <section class="archive-results" id="archive-results" aria-label="Available reports">
+        <section class="archive-results" id="archive-results" role="region" aria-label="Available reports">
             <div class="archive-list" id="archive-list"></div>
             <div class="archive-empty" id="archive-empty" hidden>
                 <p>No archived reports match that filter.</p>

--- a/tests/test_report_viewer_security.py
+++ b/tests/test_report_viewer_security.py
@@ -516,6 +516,10 @@ def test_report_archive_exposes_static_section_index():
     )
     assert 'id="archive-filter-title" for="archive-filter"' in archive
     assert 'id="archive-results"' in archive
+    assert (
+        'class="archive-results" id="archive-results" role="region" '
+        'aria-label="Available reports"' in archive
+    )
     assert 'id="archive-list"' in archive
     assert "#archive-summary, #archive-filter-panel, #archive-results" in archive
     assert "scroll-margin-top: 32px" in archive


### PR DESCRIPTION
## Summary
- Expose the archive results container as a named region.
- Preserve the existing available-reports label and guard the static archive contract with a focused test.

## Motivation
The archive section-index Reports target should land on a region with a stable accessible name.

## Validation
- `uv run pytest tests/test_report_viewer_security.py -q`
- `bash scripts/local_validation.sh`

Closes #135