### PR TITLE
Generate reports via OpenRouter directly so CI no longer needs OpenCode

### DIFF
--- a/.github/workflows/generate-report.yml
+++ b/.github/workflows/generate-report.yml
@@ -38,8 +38,10 @@ jobs:
       - name: Generate exploitation report
         run: uv run python main.py
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          SENTRYINSIGHT_ANTHROPIC_MODEL: ${{ vars.SENTRYINSIGHT_ANTHROPIC_MODEL || 'claude-sonnet-4-6' }}
+          # Report generation calls OpenRouter directly (free model default);
+          # no local OpenCode gateway is needed in CI.
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          SENTRYINSIGHT_MODEL: ${{ vars.SENTRYINSIGHT_MODEL || 'openrouter/nvidia/nemotron-3-ultra-550b-a55b:free' }}
           ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
           # Pass VT Intelligence API key under multiple common env names
           VT_API_KEY: ${{ secrets.VT_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Automated cybersecurity threat intelligence that monitors RSS feeds and generate
 
 - **LangGraph**: Orchestrates workflow state and conditional logic
 - **FastMCP**: Code organization with decorators for RSS tools
-- **OpenCode**: Provider-switchable report generation
+- **Model access**: Calls OpenRouter directly when `OPENROUTER_API_KEY` is set
+  (used in CI; no local server required); otherwise routes through a local
+  OpenCode gateway for development
 
 ## Setup
 
@@ -28,7 +30,11 @@ Automated cybersecurity threat intelligence that monitors RSS feeds and generate
    uv sync --group dev
    ```
 
-2. Start an OpenCode server with access to your preferred model provider:
+2. Provide model access. Either call OpenRouter directly (also how CI runs):
+   ```bash
+   export OPENROUTER_API_KEY=...   # free model default; no local server needed
+   ```
+   or start a local OpenCode server with access to your preferred provider:
    ```bash
    opencode serve --port 4096
    ```

--- a/src/core/analyze.py
+++ b/src/core/analyze.py
@@ -7,7 +7,8 @@ from datetime import datetime
 import tiktoken
 
 from .model_config import resolve_model, validate_model
-from .opencode_client import OpenCodeClient, OpenCodeUnavailable, parse_model_selection
+from .model_client import build_model_client
+from .opencode_client import OpenCodeUnavailable, parse_model_selection
 from .entities import extract_cve_ids
 from .source_attribution import (
     clean_article_source,
@@ -406,7 +407,9 @@ Generate a well-formatted exploitation report following the structure above. Be 
 
     # Call the AI model
     try:
-        client = OpenCodeClient(timeout=max(120.0, float(max_tokens) / 20))
+        client = build_model_client(
+            timeout=max(120.0, float(max_tokens) / 20), max_tokens=max_tokens
+        )
         exploitation_report = await client.generate(
             system_prompt="You are a cybersecurity threat hunter specializing in vulnerability exploitation analysis. Your task is to create a comprehensive report on current exploit activity based on recent security articles. Be extremely thorough in identifying ALL exploited vulnerabilities mentioned in the articles, including zero-days, active exploits, and recently patched vulnerabilities that were exploited in the wild.",
             user_prompt=prompt,

--- a/src/core/model_client.py
+++ b/src/core/model_client.py
@@ -1,0 +1,28 @@
+"""Select the model client used for report generation.
+
+Prefer a direct OpenRouter client when an API key is configured, so the
+pipeline can run without a locally hosted OpenCode gateway (for example in CI).
+Otherwise fall back to OpenCode for local development. Both clients expose the
+same ``generate`` contract.
+"""
+
+from __future__ import annotations
+
+import os
+
+from .opencode_client import OpenCodeClient
+from .openrouter_client import OPENROUTER_API_KEY_ENV_VAR, OpenRouterClient
+
+
+def build_model_client(
+    *, timeout: float, max_tokens: int
+) -> OpenCodeClient | OpenRouterClient:
+    """Return the model client selected by the environment.
+
+    Uses OpenRouter directly when ``OPENROUTER_API_KEY`` is set; otherwise uses
+    a local OpenCode server.
+    """
+    api_key = os.getenv(OPENROUTER_API_KEY_ENV_VAR, "").strip()
+    if api_key:
+        return OpenRouterClient(api_key=api_key, max_tokens=max_tokens, timeout=timeout)
+    return OpenCodeClient(timeout=timeout)

--- a/src/core/openrouter_client.py
+++ b/src/core/openrouter_client.py
@@ -1,0 +1,113 @@
+"""Direct OpenRouter chat-completions client for report generation.
+
+Used when an ``OPENROUTER_API_KEY`` is configured (for example in CI) so report
+generation does not depend on a locally running OpenCode gateway. Exposes the
+same ``generate`` contract as :class:`~src.core.opencode_client.OpenCodeClient`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from .opencode_client import ModelSelection
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+OPENROUTER_API_KEY_ENV_VAR = "OPENROUTER_API_KEY"
+
+
+class OpenRouterError(RuntimeError):
+    """Raised when OpenRouter cannot return usable model output."""
+
+
+class OpenRouterUnavailable(OpenRouterError):
+    """Raised when the OpenRouter API cannot be reached."""
+
+
+class OpenRouterClient:
+    """Small async client for OpenRouter chat completions."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        max_tokens: int = 4000,
+        base_url: str = OPENROUTER_BASE_URL,
+        timeout: float = 120.0,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self.api_key = api_key
+        self.max_tokens = max_tokens
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.transport = transport
+
+    async def generate(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+        model: ModelSelection | None = None,
+        title: str = "Report generation",
+    ) -> str:
+        """Generate text through the OpenRouter chat completions API."""
+        if model is None or model.provider_id != "openrouter":
+            raise OpenRouterError("OpenRouter calls require an openrouter/* model")
+
+        try:
+            async with httpx.AsyncClient(
+                base_url=self.base_url,
+                timeout=self.timeout,
+                transport=self.transport,
+                headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                    "X-Title": title,
+                },
+            ) as client:
+                response = await client.post(
+                    "/chat/completions",
+                    json={
+                        "model": model.model_id,
+                        "max_tokens": self.max_tokens,
+                        "messages": [
+                            {"role": "system", "content": system_prompt},
+                            {"role": "user", "content": user_prompt},
+                        ],
+                    },
+                )
+        except httpx.TransportError as e:
+            # Keep the message generic so connection details never leak.
+            raise OpenRouterUnavailable("OpenRouter API unavailable") from e
+
+        self._raise_for_status(response)
+        return self._extract_text(response.json())
+
+    def _raise_for_status(self, response: httpx.Response) -> None:
+        if response.is_success:
+            return
+        # Surface only the status code; the body may echo prompt content.
+        raise OpenRouterError(
+            f"OpenRouter chat completion failed: HTTP {response.status_code}"
+        )
+
+    def _extract_text(self, payload: dict[str, Any]) -> str:
+        choices = payload.get("choices")
+        if not isinstance(choices, list):
+            raise OpenRouterError("OpenRouter response did not include choices")
+
+        text_parts: list[str] = []
+        for choice in choices:
+            if not isinstance(choice, dict):
+                continue
+            message = choice.get("message")
+            if isinstance(message, dict):
+                content = message.get("content")
+                if isinstance(content, str) and content.strip():
+                    text_parts.append(content)
+
+        if text_parts:
+            return "\n".join(text_parts)
+
+        raise OpenRouterError("OpenRouter response did not include text output")

--- a/tests/test_analyze_guards.py
+++ b/tests/test_analyze_guards.py
@@ -23,12 +23,18 @@ def import_analyze_with_stubs():
     class OpenCodeClient:
         pass
 
+    class ModelSelection:
+        def __init__(self, provider_id="", model_id=""):
+            self.provider_id = provider_id
+            self.model_id = model_id
+
     def parse_model_selection(model_name):
         provider_id, model_id = model_name.split("/", 1)
         return types.SimpleNamespace(provider_id=provider_id, model_id=model_id)
 
     opencode_client_module.OpenCodeClient = OpenCodeClient
     opencode_client_module.OpenCodeUnavailable = OpenCodeUnavailable
+    opencode_client_module.ModelSelection = ModelSelection
     opencode_client_module.parse_model_selection = parse_model_selection
 
     with patch.dict(
@@ -76,7 +82,7 @@ class AnalyzeGuardTests(unittest.TestCase):
                 )
                 return "# Exploitation Report\n\nGenerated through OpenCode."
 
-        analyze.OpenCodeClient = FakeOpenCodeClient
+        analyze.build_model_client = lambda **kwargs: FakeOpenCodeClient(**kwargs)
 
         with patch.dict(os.environ, {}, clear=True):
             result = asyncio.run(
@@ -103,7 +109,7 @@ class AnalyzeGuardTests(unittest.TestCase):
             async def generate(self, **_kwargs):
                 raise analyze.OpenCodeUnavailable("OpenCode server unavailable")
 
-        analyze.OpenCodeClient = FakeOpenCodeClient
+        analyze.build_model_client = lambda **kwargs: FakeOpenCodeClient(**kwargs)
 
         with patch.dict(os.environ, {}, clear=True):
             result = asyncio.run(
@@ -133,7 +139,7 @@ class AnalyzeGuardTests(unittest.TestCase):
                 self.__class__.user_prompt = user_prompt
                 return "# Exploitation Report\n\nGenerated through OpenCode."
 
-        analyze.OpenCodeClient = FakeOpenCodeClient
+        analyze.build_model_client = lambda **kwargs: FakeOpenCodeClient(**kwargs)
 
         with patch.dict(os.environ, {}, clear=True):
             asyncio.run(
@@ -169,7 +175,7 @@ class AnalyzeGuardTests(unittest.TestCase):
             async def generate(self, **_kwargs):
                 return "# Exploitation Report\n\nGenerated through OpenCode."
 
-        analyze.OpenCodeClient = FakeOpenCodeClient
+        analyze.build_model_client = lambda **kwargs: FakeOpenCodeClient(**kwargs)
 
         with patch.dict(os.environ, {}, clear=True):
             result = asyncio.run(
@@ -212,7 +218,7 @@ class AnalyzeGuardTests(unittest.TestCase):
             async def generate(self, **_kwargs):
                 return "# Exploitation Report\n\nGenerated through OpenCode."
 
-        analyze.OpenCodeClient = FakeOpenCodeClient
+        analyze.build_model_client = lambda **kwargs: FakeOpenCodeClient(**kwargs)
 
         with patch.dict(os.environ, {}, clear=True):
             result = asyncio.run(
@@ -254,7 +260,7 @@ class AnalyzeGuardTests(unittest.TestCase):
             async def generate(self, **_kwargs):
                 return "# Exploitation Report\n\nGenerated through OpenCode."
 
-        analyze.OpenCodeClient = FakeOpenCodeClient
+        analyze.build_model_client = lambda **kwargs: FakeOpenCodeClient(**kwargs)
 
         with patch.dict(os.environ, {}, clear=True):
             result = asyncio.run(
@@ -291,7 +297,7 @@ class AnalyzeGuardTests(unittest.TestCase):
             async def generate(self, **_kwargs):
                 return "# Exploitation Report\n\nGenerated through OpenCode."
 
-        analyze.OpenCodeClient = FakeOpenCodeClient
+        analyze.build_model_client = lambda **kwargs: FakeOpenCodeClient(**kwargs)
 
         with patch.dict(os.environ, {}, clear=True):
             result = asyncio.run(
@@ -326,7 +332,7 @@ class AnalyzeGuardTests(unittest.TestCase):
             async def generate(self, **_kwargs):
                 return "# Exploitation Report\n\nGenerated through OpenCode."
 
-        analyze.OpenCodeClient = FakeOpenCodeClient
+        analyze.build_model_client = lambda **kwargs: FakeOpenCodeClient(**kwargs)
 
         with patch.dict(os.environ, {}, clear=True):
             result = asyncio.run(
@@ -361,7 +367,7 @@ class AnalyzeGuardTests(unittest.TestCase):
             async def generate(self, **_kwargs):
                 return "# Exploitation Report\n\nGenerated through OpenCode."
 
-        analyze.OpenCodeClient = FakeOpenCodeClient
+        analyze.build_model_client = lambda **kwargs: FakeOpenCodeClient(**kwargs)
 
         with patch.dict(os.environ, {}, clear=True):
             result = asyncio.run(
@@ -393,7 +399,7 @@ class AnalyzeGuardTests(unittest.TestCase):
             async def generate(self, **_kwargs):
                 return "# Exploitation Report\n\nGenerated through OpenCode."
 
-        analyze.OpenCodeClient = FakeOpenCodeClient
+        analyze.build_model_client = lambda **kwargs: FakeOpenCodeClient(**kwargs)
 
         with patch.dict(os.environ, {}, clear=True):
             result = asyncio.run(
@@ -428,7 +434,7 @@ class AnalyzeGuardTests(unittest.TestCase):
             async def generate(self, **_kwargs):
                 return "# Exploitation Report\n\nGenerated through OpenCode."
 
-        analyze.OpenCodeClient = FakeOpenCodeClient
+        analyze.build_model_client = lambda **kwargs: FakeOpenCodeClient(**kwargs)
 
         with patch.dict(os.environ, {}, clear=True):
             result = asyncio.run(
@@ -460,7 +466,7 @@ class AnalyzeGuardTests(unittest.TestCase):
             async def generate(self, **_kwargs):
                 return "# Exploitation Report\n\nGenerated through OpenCode."
 
-        analyze.OpenCodeClient = FakeOpenCodeClient
+        analyze.build_model_client = lambda **kwargs: FakeOpenCodeClient(**kwargs)
 
         with patch.dict(os.environ, {}, clear=True):
             result = asyncio.run(
@@ -495,7 +501,7 @@ class AnalyzeGuardTests(unittest.TestCase):
             async def generate(self, **_kwargs):
                 return "# Exploitation Report\n\nGenerated through OpenCode."
 
-        analyze.OpenCodeClient = FakeOpenCodeClient
+        analyze.build_model_client = lambda **kwargs: FakeOpenCodeClient(**kwargs)
 
         with patch.dict(os.environ, {}, clear=True):
             result = asyncio.run(
@@ -528,7 +534,7 @@ class AnalyzeGuardTests(unittest.TestCase):
             async def generate(self, **_kwargs):
                 return "# Exploitation Report\n\nGenerated through OpenCode."
 
-        analyze.OpenCodeClient = FakeOpenCodeClient
+        analyze.build_model_client = lambda **kwargs: FakeOpenCodeClient(**kwargs)
 
         with patch.dict(os.environ, {}, clear=True):
             result = asyncio.run(
@@ -560,7 +566,7 @@ class AnalyzeGuardTests(unittest.TestCase):
             async def generate(self, **_kwargs):
                 return "# Exploitation Report\n\nGenerated through OpenCode."
 
-        analyze.OpenCodeClient = FakeOpenCodeClient
+        analyze.build_model_client = lambda **kwargs: FakeOpenCodeClient(**kwargs)
 
         with patch.dict(os.environ, {}, clear=True):
             result = asyncio.run(
@@ -596,7 +602,7 @@ class AnalyzeGuardTests(unittest.TestCase):
             async def generate(self, **_kwargs):
                 return "# Exploitation Report\n\nGenerated through OpenCode."
 
-        analyze.OpenCodeClient = FakeOpenCodeClient
+        analyze.build_model_client = lambda **kwargs: FakeOpenCodeClient(**kwargs)
 
         with patch.dict(os.environ, {}, clear=True):
             result = asyncio.run(
@@ -632,7 +638,7 @@ class AnalyzeGuardTests(unittest.TestCase):
             async def generate(self, **_kwargs):
                 return "# Exploitation Report\n\nGenerated through OpenCode."
 
-        analyze.OpenCodeClient = FakeOpenCodeClient
+        analyze.build_model_client = lambda **kwargs: FakeOpenCodeClient(**kwargs)
 
         with patch.dict(os.environ, {}, clear=True):
             result = asyncio.run(
@@ -669,7 +675,7 @@ class AnalyzeGuardTests(unittest.TestCase):
                 self.__class__.user_prompt = kwargs["user_prompt"]
                 return "# Exploitation Report\n\nGenerated through OpenCode."
 
-        analyze.OpenCodeClient = FakeOpenCodeClient
+        analyze.build_model_client = lambda **kwargs: FakeOpenCodeClient(**kwargs)
 
         with patch.dict(os.environ, {}, clear=True):
             asyncio.run(
@@ -709,7 +715,7 @@ class AnalyzeGuardTests(unittest.TestCase):
             async def generate(self, **_kwargs):
                 return "# Exploitation Report\n\nGenerated through OpenCode."
 
-        analyze.OpenCodeClient = FakeOpenCodeClient
+        analyze.build_model_client = lambda **kwargs: FakeOpenCodeClient(**kwargs)
 
         with patch.dict(os.environ, {}, clear=True):
             result = asyncio.run(

--- a/tests/test_model_client.py
+++ b/tests/test_model_client.py
@@ -1,0 +1,35 @@
+import os
+import unittest
+from unittest import mock
+
+from src.core.model_client import build_model_client
+from src.core.opencode_client import OpenCodeClient
+from src.core.openrouter_client import OpenRouterClient
+
+
+class BuildModelClientTests(unittest.TestCase):
+    def test_uses_openrouter_when_api_key_present(self):
+        with mock.patch.dict(
+            os.environ, {"OPENROUTER_API_KEY": "test-key"}, clear=False
+        ):
+            client = build_model_client(timeout=120.0, max_tokens=4000)
+
+        self.assertIsInstance(client, OpenRouterClient)
+        self.assertEqual(client.api_key, "test-key")
+        self.assertEqual(client.max_tokens, 4000)
+
+    def test_falls_back_to_opencode_without_api_key(self):
+        with mock.patch.dict(os.environ, {"OPENROUTER_API_KEY": ""}, clear=False):
+            client = build_model_client(timeout=120.0, max_tokens=4000)
+
+        self.assertIsInstance(client, OpenCodeClient)
+
+    def test_blank_api_key_falls_back_to_opencode(self):
+        with mock.patch.dict(os.environ, {"OPENROUTER_API_KEY": "   "}, clear=False):
+            client = build_model_client(timeout=120.0, max_tokens=4000)
+
+        self.assertIsInstance(client, OpenCodeClient)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_openrouter_client.py
+++ b/tests/test_openrouter_client.py
@@ -1,0 +1,140 @@
+import asyncio
+import json
+import unittest
+
+import httpx
+
+from src.core.opencode_client import parse_model_selection
+from src.core.openrouter_client import (
+    OpenRouterClient,
+    OpenRouterError,
+    OpenRouterUnavailable,
+)
+
+FREE_MODEL = "openrouter/nvidia/nemotron-3-ultra-550b-a55b:free"
+
+
+class OpenRouterClientTests(unittest.TestCase):
+    def test_generate_posts_chat_completion_with_model(self):
+        requests = []
+
+        def handler(request):
+            requests.append(request)
+            payload = json.loads(request.content.decode())
+            self.assertEqual(payload["model"], "nvidia/nemotron-3-ultra-550b-a55b:free")
+            self.assertEqual(payload["max_tokens"], 1234)
+            self.assertEqual(
+                payload["messages"][0], {"role": "system", "content": "system"}
+            )
+            self.assertEqual(
+                payload["messages"][1], {"role": "user", "content": "user"}
+            )
+            return httpx.Response(
+                200,
+                json={"choices": [{"message": {"content": "Generated report"}}]},
+            )
+
+        client = OpenRouterClient(
+            api_key="secret-key",
+            max_tokens=1234,
+            transport=httpx.MockTransport(handler),
+        )
+
+        result = asyncio.run(
+            client.generate(
+                system_prompt="system",
+                user_prompt="user",
+                model=parse_model_selection(FREE_MODEL),
+            )
+        )
+
+        self.assertEqual(result, "Generated report")
+        self.assertEqual(requests[0].url.path, "/api/v1/chat/completions")
+        self.assertEqual(requests[0].headers["Authorization"], "Bearer secret-key")
+
+    def test_generate_redacts_failed_response_body(self):
+        def handler(request):
+            return httpx.Response(500, text="secret prompt fragment")
+
+        client = OpenRouterClient(
+            api_key="secret-key",
+            transport=httpx.MockTransport(handler),
+        )
+
+        with self.assertRaisesRegex(
+            OpenRouterError,
+            r"OpenRouter chat completion failed: HTTP 500",
+        ) as raised:
+            asyncio.run(
+                client.generate(
+                    system_prompt="system",
+                    user_prompt="user",
+                    model=parse_model_selection(FREE_MODEL),
+                )
+            )
+
+        self.assertNotIn("secret prompt fragment", str(raised.exception))
+        self.assertNotIn("secret-key", str(raised.exception))
+
+    def test_generate_classifies_connection_failure_as_unavailable(self):
+        def handler(request):
+            raise httpx.ConnectError("secret connection detail", request=request)
+
+        client = OpenRouterClient(
+            api_key="secret-key",
+            transport=httpx.MockTransport(handler),
+        )
+
+        with self.assertRaisesRegex(
+            OpenRouterUnavailable,
+            "OpenRouter API unavailable",
+        ) as raised:
+            asyncio.run(
+                client.generate(
+                    system_prompt="system",
+                    user_prompt="user",
+                    model=parse_model_selection(FREE_MODEL),
+                )
+            )
+
+        self.assertNotIn("secret connection detail", str(raised.exception))
+
+    def test_generate_rejects_non_openrouter_model(self):
+        def handler(request):
+            raise AssertionError("must not call the API for a non-openrouter model")
+
+        client = OpenRouterClient(
+            api_key="secret-key",
+            transport=httpx.MockTransport(handler),
+        )
+
+        with self.assertRaisesRegex(OpenRouterError, "openrouter"):
+            asyncio.run(
+                client.generate(
+                    system_prompt="system",
+                    user_prompt="user",
+                    model=parse_model_selection("anthropic/claude-sonnet-4-6"),
+                )
+            )
+
+    def test_generate_requires_text_output(self):
+        def handler(request):
+            return httpx.Response(200, json={"choices": [{"message": {"content": ""}}]})
+
+        client = OpenRouterClient(
+            api_key="secret-key",
+            transport=httpx.MockTransport(handler),
+        )
+
+        with self.assertRaisesRegex(OpenRouterError, "did not include text output"):
+            asyncio.run(
+                client.generate(
+                    system_prompt="system",
+                    user_prompt="user",
+                    model=parse_model_selection(FREE_MODEL),
+                )
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a direct OpenRouter model client (same `generate()` contract as OpenCode), selected by environment: OpenRouter when `OPENROUTER_API_KEY` is set (CI, free model default), else local OpenCode. Points the workflow at `OPENROUTER_API_KEY` and drops the unused Anthropic env. Failures now surface loudly instead of silently serving stale content. Adds tests for the client and selector; full local validation passes.

Requires the `OPENROUTER_API_KEY` repository secret (already added).

Closes #141