### PR TITLE
Raise report token budget so OpenRouter output is not truncated

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -3,7 +3,7 @@
     "output_path": "index.md",
     "analysis": {
         "model": "openrouter/nvidia/nemotron-3-ultra-550b-a55b:free",
-        "max_tokens": 4000,
+        "max_tokens": 16000,
         "temperature": 1,
         "analysis_focus": [
             "zero-day vulnerabilities",


### PR DESCRIPTION
Follow-up to the OpenRouter integration. The OpenRouter client sends `max_tokens` as an output cap (the OpenCode gateway never did), so the prior value of 4000 truncated the report before its trailing required sections, and the publish validator correctly rejected it. Raises `analysis.max_tokens` to 16000 (matching the working GRCInsight budget), which also widens the request timeout.

Refs #141