### PR TITLE
Publish executive summary audio atomically

### DIFF
--- a/src/services/audio.py
+++ b/src/services/audio.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+import tempfile
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -81,6 +82,7 @@ async def generate_executive_summary_audio(
 
     logger.info(f"Generating audio for executive summary ({len(summary_text)} chars)")
 
+    temporary_path: Path | None = None
     try:
         from elevenlabs.client import ElevenLabs
 
@@ -92,13 +94,33 @@ async def generate_executive_summary_audio(
             output_format=OUTPUT_FORMAT,
         )
 
-        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
-        with open(output_path, "wb") as f:
+        destination = Path(output_path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        bytes_written = 0
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            dir=destination.parent,
+            prefix=f".{destination.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as f:
+            temporary_path = Path(f.name)
             for chunk in audio:
-                f.write(chunk)
+                if chunk:
+                    bytes_written += f.write(chunk)
+            f.flush()
+            os.fsync(f.fileno())
+
+        if bytes_written == 0:
+            raise ValueError("audio provider returned an empty stream")
+
+        os.replace(temporary_path, destination)
+        temporary_path = None
 
         logger.info(f"Audio saved to {output_path}")
         return True
     except Exception as e:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
         logger.error(f"Error generating audio: {e}")
         return False

--- a/src/services/audio.py
+++ b/src/services/audio.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+import stat
 import tempfile
 from pathlib import Path
 
@@ -96,6 +97,9 @@ async def generate_executive_summary_audio(
 
         destination = Path(output_path)
         destination.parent.mkdir(parents=True, exist_ok=True)
+        destination_mode = (
+            stat.S_IMODE(destination.stat().st_mode) if destination.exists() else 0o644
+        )
         bytes_written = 0
         with tempfile.NamedTemporaryFile(
             mode="wb",
@@ -114,6 +118,7 @@ async def generate_executive_summary_audio(
         if bytes_written == 0:
             raise ValueError("audio provider returned an empty stream")
 
+        os.chmod(temporary_path, destination_mode)
         os.replace(temporary_path, destination)
         temporary_path = None
 

--- a/src/services/audio.py
+++ b/src/services/audio.py
@@ -83,7 +83,6 @@ async def generate_executive_summary_audio(
 
     logger.info(f"Generating audio for executive summary ({len(summary_text)} chars)")
 
-    temporary_path: Path | None = None
     try:
         from elevenlabs.client import ElevenLabs
 
@@ -97,35 +96,33 @@ async def generate_executive_summary_audio(
 
         destination = Path(output_path)
         destination.parent.mkdir(parents=True, exist_ok=True)
-        destination_mode = (
-            stat.S_IMODE(destination.stat().st_mode) if destination.exists() else 0o644
-        )
-        bytes_written = 0
-        with tempfile.NamedTemporaryFile(
-            mode="wb",
+        try:
+            destination_mode = stat.S_IMODE(destination.stat().st_mode)
+        except FileNotFoundError:
+            destination_mode = None
+
+        with tempfile.TemporaryDirectory(
             dir=destination.parent,
             prefix=f".{destination.name}.",
-            suffix=".tmp",
-            delete=False,
-        ) as f:
-            temporary_path = Path(f.name)
-            for chunk in audio:
-                if chunk:
-                    bytes_written += f.write(chunk)
-            f.flush()
-            os.fsync(f.fileno())
+        ) as temporary_directory:
+            temporary_path = Path(temporary_directory) / destination.name
+            bytes_written = 0
+            with temporary_path.open("xb") as f:
+                for chunk in audio:
+                    if chunk:
+                        bytes_written += f.write(chunk)
+                f.flush()
+                os.fsync(f.fileno())
 
-        if bytes_written == 0:
-            raise ValueError("audio provider returned an empty stream")
+            if bytes_written == 0:
+                raise ValueError("audio provider returned an empty stream")
 
-        os.chmod(temporary_path, destination_mode)
-        os.replace(temporary_path, destination)
-        temporary_path = None
+            if destination_mode is not None:
+                os.chmod(temporary_path, destination_mode)
+            os.replace(temporary_path, destination)
 
         logger.info(f"Audio saved to {output_path}")
         return True
     except Exception as e:
-        if temporary_path is not None:
-            temporary_path.unlink(missing_ok=True)
         logger.error(f"Error generating audio: {e}")
         return False

--- a/tests/test_audio_summary.py
+++ b/tests/test_audio_summary.py
@@ -1,4 +1,29 @@
-from src.services.audio import extract_executive_summary
+import asyncio
+import sys
+import types
+from unittest.mock import patch
+
+from src.services.audio import (
+    extract_executive_summary,
+    generate_executive_summary_audio,
+)
+
+
+def install_fake_elevenlabs(audio):
+    client_module = types.ModuleType("elevenlabs.client")
+
+    class FakeElevenLabs:
+        def __init__(self, *, api_key):
+            assert api_key == "test-key"
+            self.text_to_speech = types.SimpleNamespace(convert=lambda **_kwargs: audio)
+
+    client_module.ElevenLabs = FakeElevenLabs
+    package_module = types.ModuleType("elevenlabs")
+    package_module.client = client_module
+    return {
+        "elevenlabs": package_module,
+        "elevenlabs.client": client_module,
+    }
 
 
 def test_extract_executive_summary_reads_named_section():
@@ -33,3 +58,67 @@ Legacy executive paragraph.
 """
 
     assert extract_executive_summary(report) == "Legacy executive paragraph."
+
+
+def test_audio_generation_preserves_previous_file_when_stream_fails(tmp_path):
+    def interrupted_audio():
+        yield b"partial replacement"
+        raise RuntimeError("stream interrupted")
+
+    output_path = tmp_path / "executive_summary.mp3"
+    output_path.write_bytes(b"previous valid audio")
+
+    with (
+        patch.dict("os.environ", {"ELEVENLABS_API_KEY": "test-key"}),
+        patch.dict(sys.modules, install_fake_elevenlabs(interrupted_audio())),
+    ):
+        result = asyncio.run(
+            generate_executive_summary_audio(
+                "# Exploitation Report\n\n## Executive Summary\n\nExample.",
+                str(output_path),
+            )
+        )
+
+    assert result is False
+    assert output_path.read_bytes() == b"previous valid audio"
+    assert list(tmp_path.iterdir()) == [output_path]
+
+
+def test_audio_generation_atomically_replaces_previous_file(tmp_path):
+    output_path = tmp_path / "executive_summary.mp3"
+    output_path.write_bytes(b"previous valid audio")
+
+    with (
+        patch.dict("os.environ", {"ELEVENLABS_API_KEY": "test-key"}),
+        patch.dict(sys.modules, install_fake_elevenlabs([b"new ", b"audio"])),
+    ):
+        result = asyncio.run(
+            generate_executive_summary_audio(
+                "# Exploitation Report\n\n## Executive Summary\n\nExample.",
+                str(output_path),
+            )
+        )
+
+    assert result is True
+    assert output_path.read_bytes() == b"new audio"
+    assert list(tmp_path.iterdir()) == [output_path]
+
+
+def test_audio_generation_preserves_previous_file_when_stream_is_empty(tmp_path):
+    output_path = tmp_path / "executive_summary.mp3"
+    output_path.write_bytes(b"previous valid audio")
+
+    with (
+        patch.dict("os.environ", {"ELEVENLABS_API_KEY": "test-key"}),
+        patch.dict(sys.modules, install_fake_elevenlabs([])),
+    ):
+        result = asyncio.run(
+            generate_executive_summary_audio(
+                "# Exploitation Report\n\n## Executive Summary\n\nExample.",
+                str(output_path),
+            )
+        )
+
+    assert result is False
+    assert output_path.read_bytes() == b"previous valid audio"
+    assert list(tmp_path.iterdir()) == [output_path]

--- a/tests/test_audio_summary.py
+++ b/tests/test_audio_summary.py
@@ -87,6 +87,7 @@ def test_audio_generation_preserves_previous_file_when_stream_fails(tmp_path):
 def test_audio_generation_atomically_replaces_previous_file(tmp_path):
     output_path = tmp_path / "executive_summary.mp3"
     output_path.write_bytes(b"previous valid audio")
+    output_path.chmod(0o640)
 
     with (
         patch.dict("os.environ", {"ELEVENLABS_API_KEY": "test-key"}),
@@ -101,6 +102,7 @@ def test_audio_generation_atomically_replaces_previous_file(tmp_path):
 
     assert result is True
     assert output_path.read_bytes() == b"new audio"
+    assert output_path.stat().st_mode & 0o777 == 0o640
     assert list(tmp_path.iterdir()) == [output_path]
 
 

--- a/tests/test_audio_summary.py
+++ b/tests/test_audio_summary.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import sys
 import types
 from unittest.mock import patch
@@ -103,6 +104,29 @@ def test_audio_generation_atomically_replaces_previous_file(tmp_path):
     assert result is True
     assert output_path.read_bytes() == b"new audio"
     assert output_path.stat().st_mode & 0o777 == 0o640
+    assert list(tmp_path.iterdir()) == [output_path]
+
+
+def test_audio_generation_honors_umask_for_new_file(tmp_path):
+    output_path = tmp_path / "executive_summary.mp3"
+    previous_umask = os.umask(0o077)
+    try:
+        with (
+            patch.dict("os.environ", {"ELEVENLABS_API_KEY": "test-key"}),
+            patch.dict(sys.modules, install_fake_elevenlabs([b"new audio"])),
+        ):
+            result = asyncio.run(
+                generate_executive_summary_audio(
+                    "# Exploitation Report\n\n## Executive Summary\n\nExample.",
+                    str(output_path),
+                )
+            )
+    finally:
+        os.umask(previous_umask)
+
+    assert result is True
+    assert output_path.read_bytes() == b"new audio"
+    assert output_path.stat().st_mode & 0o777 == 0o600
     assert list(tmp_path.iterdir()) == [output_path]
 
 


### PR DESCRIPTION
## Summary
- Write generated executive summary audio to a same-directory temporary file.
- Replace the published MP3 only after a complete, non-empty stream.
- Preserve the previous artifact and remove temporary files when generation fails.

## Motivation
A provider interruption could leave a partial non-empty MP3 at the public path even though generation returned failure. Empty streams could also replace a valid artifact.

## Validation
- `bash scripts/local_validation.sh`

Closes #144