### PR TITLE
Close feed clients after retrieval

### DIFF
--- a/src/services/fetch.py
+++ b/src/services/fetch.py
@@ -24,7 +24,29 @@ class SentryDigestFeedClient:
             feed_url: URL of the SentryDigest RSS feed
         """
         self.feed_url = feed_url
-        self.client = httpx.AsyncClient(follow_redirects=True, timeout=30.0)
+        self.client = None
+
+    async def _fetch_articles_with_client(
+        self, client: httpx.AsyncClient
+    ) -> List[Dict[str, Any]]:
+        response = await client.get(self.feed_url)
+        response.raise_for_status()
+
+        feed = feedparser.parse(response.text)
+        articles = []
+        for entry in feed.entries:
+            articles.append(
+                {
+                    "title": entry.get("title", ""),
+                    "link": entry.get("link", ""),
+                    "summary": entry.get("description", ""),
+                    "published": entry.get("published", ""),
+                    "source": entry.get("dc_source", "Unknown Source"),
+                    "date": entry.get("dc_date", datetime.now().strftime("%Y-%m-%d")),
+                    "content": entry.get("content", ""),
+                }
+            )
+        return articles
 
     async def fetch_articles(self) -> List[Dict[str, Any]]:
         """
@@ -36,27 +58,13 @@ class SentryDigestFeedClient:
         logger.info(f"Fetching articles from {self.feed_url}")
 
         try:
-            # Fetch the feed
-            response = await self.client.get(self.feed_url)
-            response.raise_for_status()
-
-            # Use feedparser to parse the feed
-            feed = feedparser.parse(response.text)
-
-            # Extract articles
-            articles = []
-            for entry in feed.entries:
-                # Basic article info
-                article = {
-                    "title": entry.get("title", ""),
-                    "link": entry.get("link", ""),
-                    "summary": entry.get("description", ""),
-                    "published": entry.get("published", ""),
-                    "source": entry.get("dc_source", "Unknown Source"),
-                    "date": entry.get("dc_date", datetime.now().strftime("%Y-%m-%d")),
-                    "content": entry.get("content", ""),
-                }
-                articles.append(article)
+            if self.client is not None:
+                articles = await self._fetch_articles_with_client(self.client)
+            else:
+                async with httpx.AsyncClient(
+                    follow_redirects=True, timeout=30.0
+                ) as client:
+                    articles = await self._fetch_articles_with_client(client)
 
             logger.info(f"Extracted {len(articles)} articles from feed")
             return articles

--- a/tests/test_feed_client.py
+++ b/tests/test_feed_client.py
@@ -34,6 +34,25 @@ class TrackingArticleClient:
         raise AssertionError("missing article links should not be fetched")
 
 
+class TrackingFeedClient:
+    exit_calls = 0
+    should_fail = False
+
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        type(self).exit_calls += 1
+
+    async def get(self, _url):
+        if type(self).should_fail:
+            raise RuntimeError("feed unavailable")
+        return FakeResponse()
+
+
 def test_fetch_articles_preserves_safe_defaults_for_sparse_feed_entries(monkeypatch):
     monkeypatch.setattr(
         fetch_module.feedparser,
@@ -78,3 +97,38 @@ def test_enrich_article_content_skips_full_fetch_when_link_is_missing(monkeypatc
 
     assert articles[0]["content"] == "Sparse article\nSummary only\n"
     assert TrackingArticleClient.called is False
+
+
+def test_default_feed_client_closes_after_success(monkeypatch):
+    TrackingFeedClient.exit_calls = 0
+    TrackingFeedClient.should_fail = False
+    monkeypatch.setattr(fetch_module.httpx, "AsyncClient", TrackingFeedClient)
+    monkeypatch.setattr(
+        fetch_module.feedparser,
+        "parse",
+        lambda _text: SimpleNamespace(entries=[]),
+    )
+
+    articles = asyncio.run(
+        SentryDigestFeedClient("https://example.com/feed.xml").fetch_articles()
+    )
+
+    assert articles == []
+    assert TrackingFeedClient.exit_calls == 1
+
+
+def test_default_feed_client_closes_after_failure(monkeypatch):
+    TrackingFeedClient.exit_calls = 0
+    TrackingFeedClient.should_fail = True
+    monkeypatch.setattr(fetch_module.httpx, "AsyncClient", TrackingFeedClient)
+
+    try:
+        asyncio.run(
+            SentryDigestFeedClient("https://example.com/feed.xml").fetch_articles()
+        )
+    except RuntimeError as error:
+        assert str(error) == "feed unavailable"
+    else:
+        raise AssertionError("fetch_articles should propagate the transport failure")
+
+    assert TrackingFeedClient.exit_calls == 1


### PR DESCRIPTION
## Summary

- scope the default feed HTTP client to one retrieval
- close transport resources after successful and failed requests
- preserve support for caller-injected clients

## Validation

- `bash scripts/local_validation.sh`

Closes #146
