### PR TITLE
Stop ElevenLabs credit exhaustion by skipping unchanged reports

### DIFF
--- a/.github/workflows/generate-report.yml
+++ b/.github/workflows/generate-report.yml
@@ -5,9 +5,11 @@ on:
   repository_dispatch:
     types: [sentrydigest-updated]
   
-  # Schedule backup run (in case webhook fails)
+  # Schedule backup run (in case webhook fails). The workflow now fingerprints
+  # the source article set and skips analysis/audio generation when nothing
+  # changed, so this only needs to catch a fully missed webhook, not run often.
   schedule:
-    - cron: '30 */12 * * *'  # Run every 12 hours, offset by 30 minutes
+    - cron: '30 6 * * *'  # Run once daily at 06:30 UTC
   
   # Allow manual triggering
   workflow_dispatch:
@@ -63,6 +65,7 @@ jobs:
           git add -f index.md || true
           git add -f index.html || true
           git add -f executive_summary.mp3 || true
+          git add -f .sentryinsight-articles-fingerprint || true
           if [ -d docs ]; then
             git add -f docs/index.md || true
             git add -f docs/index.html || true

--- a/src/core/content_fingerprint.py
+++ b/src/core/content_fingerprint.py
@@ -1,0 +1,39 @@
+"""Track the source article set behind the last published report.
+
+The analysis model runs at temperature=1, so the rendered report text
+never matches byte-for-byte between runs even when the underlying
+articles are unchanged. Fingerprinting the article identities (rather
+than the LLM's rendered output) lets the workflow detect "nothing new
+happened" and skip the paid analysis/TTS steps entirely.
+"""
+
+import hashlib
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+FINGERPRINT_PATH = ".sentryinsight-articles-fingerprint"
+
+
+def compute_articles_fingerprint(articles: List[Dict[str, Any]]) -> str:
+    """Compute a stable fingerprint identifying the set of source articles."""
+    identifiers = sorted(
+        {
+            str(article.get("link") or article.get("title") or "").strip()
+            for article in articles
+        }
+        - {""}
+    )
+    return hashlib.sha256("\n".join(identifiers).encode("utf-8")).hexdigest()
+
+
+def read_stored_fingerprint(path: str = FINGERPRINT_PATH) -> Optional[str]:
+    """Read the fingerprint recorded for the last published report, if any."""
+    fingerprint_path = Path(path)
+    if not fingerprint_path.exists():
+        return None
+    return fingerprint_path.read_text().strip() or None
+
+
+def write_stored_fingerprint(fingerprint: str, path: str = FINGERPRINT_PATH) -> None:
+    """Persist the fingerprint for the report just published."""
+    Path(path).write_text(fingerprint + "\n")

--- a/src/core/workflow.py
+++ b/src/core/workflow.py
@@ -17,6 +17,12 @@ from ..services.publish import publish_to_github_pages
 from ..services.audio import (
     generate_executive_summary_audio,
 )
+from .content_fingerprint import (
+    FINGERPRINT_PATH,
+    compute_articles_fingerprint,
+    read_stored_fingerprint,
+    write_stored_fingerprint,
+)
 
 # Set up logging
 logging.basicConfig(
@@ -34,6 +40,7 @@ class ExploitationAnalysisState(TypedDict):
     status: str
     report_path: NotRequired[str]
     report_validation_errors: NotRequired[list[str]]
+    articles_fingerprint: NotRequired[str]
 
 
 # Load configuration
@@ -89,6 +96,11 @@ async def enrich_articles(
     return state
 
 
+def _fingerprint_path_for(output_path: str) -> str:
+    """Resolve the fingerprint file alongside the report's output path."""
+    return str(Path(output_path).parent / Path(FINGERPRINT_PATH).name)
+
+
 async def filter_articles(
     state: ExploitationAnalysisState,
 ) -> ExploitationAnalysisState:
@@ -99,6 +111,20 @@ async def filter_articles(
     filtered = filter_exploitation_articles(articles)
 
     state["filtered_articles"] = filtered
+
+    if filtered:
+        output_path = state["config"].get("output_path", "index.md")
+        fingerprint = compute_articles_fingerprint(filtered)
+        previous_fingerprint = read_stored_fingerprint(
+            _fingerprint_path_for(output_path)
+        )
+        state["articles_fingerprint"] = fingerprint
+        if fingerprint == previous_fingerprint:
+            logger.info(
+                "Source article set is unchanged since the last report — "
+                "skipping analysis and audio generation to avoid redundant API usage"
+            )
+            state["status"] = "completed_unchanged"
 
     return state
 
@@ -197,6 +223,11 @@ async def generate_report(
             f.write(report)
         logger.info(f"Copied report to {docs_index}")
 
+    if state.get("articles_fingerprint"):
+        write_stored_fingerprint(
+            state["articles_fingerprint"], _fingerprint_path_for(output_path)
+        )
+
     state["report_path"] = output_path
     return state
 
@@ -278,6 +309,8 @@ def should_end(state: ExploitationAnalysisState) -> str:
     """Determine if workflow should end."""
     if state.get("status") == "failed":
         return "error"
+    elif state.get("status") == "completed_unchanged":
+        return "unchanged"
     elif not state.get("filtered_articles"):
         return "no_articles"
     else:
@@ -314,6 +347,7 @@ def create_exploitation_analysis_graph() -> Any:
         should_end,
         {
             "error": END,
+            "unchanged": END,
             "no_articles": "generate_report",
             "continue": "analyze_articles",
         },

--- a/src/services/audio.py
+++ b/src/services/audio.py
@@ -9,7 +9,9 @@ logger = logging.getLogger(__name__)
 
 # Rachel - calm, professional female voice
 VOICE_ID = "21m00Tcm4TlvDq8ikWAM"
-MODEL_ID = "eleven_multilingual_v2"
+# Flash v2.5 is priced at or below eleven_multilingual_v2 depending on plan,
+# with no quality tradeoff for narrated summary text.
+MODEL_ID = "eleven_flash_v2_5"
 OUTPUT_FORMAT = "mp3_44100_128"
 
 

--- a/tests/test_content_fingerprint.py
+++ b/tests/test_content_fingerprint.py
@@ -1,0 +1,43 @@
+from src.core.content_fingerprint import (
+    compute_articles_fingerprint,
+    read_stored_fingerprint,
+    write_stored_fingerprint,
+)
+
+
+def test_fingerprint_is_stable_regardless_of_article_order():
+    articles_a = [{"link": "https://a"}, {"link": "https://b"}]
+    articles_b = [{"link": "https://b"}, {"link": "https://a"}]
+
+    assert compute_articles_fingerprint(articles_a) == compute_articles_fingerprint(
+        articles_b
+    )
+
+
+def test_fingerprint_changes_when_article_set_changes():
+    original = compute_articles_fingerprint([{"link": "https://a"}])
+    changed = compute_articles_fingerprint(
+        [{"link": "https://a"}, {"link": "https://c"}]
+    )
+
+    assert original != changed
+
+
+def test_fingerprint_falls_back_to_title_when_link_missing():
+    fingerprint = compute_articles_fingerprint([{"title": "Only a title"}])
+
+    assert fingerprint == compute_articles_fingerprint([{"title": "Only a title"}])
+
+
+def test_read_stored_fingerprint_returns_none_when_missing(tmp_path):
+    path = tmp_path / "fingerprint"
+
+    assert read_stored_fingerprint(str(path)) is None
+
+
+def test_write_and_read_stored_fingerprint_round_trip(tmp_path):
+    path = tmp_path / "fingerprint"
+
+    write_stored_fingerprint("abc123", str(path))
+
+    assert read_stored_fingerprint(str(path)) == "abc123"

--- a/tests/test_workflow_guards.py
+++ b/tests/test_workflow_guards.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib
+import os
 import sys
 import tempfile
 import types
@@ -252,6 +253,110 @@ Recent exploitation activity is concentrated in edge systems.
         result = asyncio.run(workflow.publish_results(state))
 
         self.assertIs(result, state)
+
+    def test_filter_articles_skips_analysis_when_article_set_unchanged(self):
+        from src.core.content_fingerprint import (
+            compute_articles_fingerprint,
+            write_stored_fingerprint,
+        )
+
+        workflow = import_workflow_with_stubs()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "index.md"
+            articles = [{"title": "Same story", "link": "https://example.com/a"}]
+            write_stored_fingerprint(
+                compute_articles_fingerprint(articles),
+                str(Path(tmpdir) / ".sentryinsight-articles-fingerprint"),
+            )
+
+            state = {
+                "articles": articles,
+                "config": {"output_path": str(output_path)},
+                "status": "started",
+            }
+
+            result = asyncio.run(workflow.filter_articles(state))
+
+            self.assertEqual(result["status"], "completed_unchanged")
+            self.assertEqual(workflow.should_end(result), "unchanged")
+
+    def test_filter_articles_continues_when_article_set_is_new(self):
+        workflow = import_workflow_with_stubs()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "index.md"
+            articles = [{"title": "New story", "link": "https://example.com/new"}]
+
+            state = {
+                "articles": articles,
+                "config": {"output_path": str(output_path)},
+                "status": "started",
+            }
+
+            result = asyncio.run(workflow.filter_articles(state))
+
+            self.assertNotEqual(result.get("status"), "completed_unchanged")
+            self.assertEqual(workflow.should_end(result), "continue")
+            self.assertIn("articles_fingerprint", result)
+
+    def test_generate_report_persists_fingerprint_for_next_run(self):
+        from src.core.content_fingerprint import read_stored_fingerprint
+
+        workflow = import_workflow_with_stubs()
+
+        # generate_report also copies to a hardcoded relative "docs/" path
+        # when that directory exists, so run from an isolated cwd with no
+        # "docs" subdir — otherwise this would clobber the real repo's
+        # docs/index.md.
+        original_cwd = Path.cwd()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            try:
+                state = {
+                    "analysis_results": {
+                        "exploitation_report": """# Exploitation Report
+
+## Executive Summary
+
+Recent exploitation activity is concentrated in edge systems.
+
+## Active Exploitation Details
+
+### Example Vulnerability
+- **Description**: Attackers are exploiting a vulnerable service.
+- **Impact**: Remote access.
+- **Status**: Active exploitation observed.
+
+## Affected Systems and Products
+
+- **Example Product**: Affected versions are exposed.
+
+## Attack Vectors and Techniques
+
+- **Internet-facing service**: Attackers send crafted requests.
+
+## Threat Actor Activities
+
+- **Unknown actor**: Opportunistic exploitation.
+""",
+                    },
+                    "articles_fingerprint": "test-fingerprint-value",
+                    "config": {"output_path": "index.md"},
+                    "status": "started",
+                }
+
+                result = asyncio.run(workflow.generate_report(state))
+
+                self.assertEqual(result["status"], "started")
+                fingerprint_path = Path(".sentryinsight-articles-fingerprint")
+                self.assertTrue(fingerprint_path.exists())
+                self.assertEqual(
+                    read_stored_fingerprint(str(fingerprint_path)),
+                    "test-fingerprint-value",
+                )
+            finally:
+                os.chdir(original_cwd)
 
     def test_skipped_analysis_skips_publish(self):
         workflow = import_workflow_with_stubs()


### PR DESCRIPTION
The report workflow fired on every SentryDigest dispatch (often several
times a day) and always regenerated the full LLM analysis and TTS audio,
even when the underlying articles hadn't changed. Text-hash dedup on the
LLM output wouldn't have caught this: the analysis model runs at
temperature=1, so identical source articles get reworded differently on
every run.

Add a source-article fingerprint (hashed article links/titles, not the
rendered text) computed right after filtering. If it matches the
fingerprint stored from the last published report, the workflow now
short-circuits before analysis or audio generation ever run. Also widen
the cron backup from every 12h to once daily now that frequent dispatches
are cheap, and switch the TTS model to eleven_flash_v2_5 as a secondary
cost guard.